### PR TITLE
Add pre/post checksum to LTX file header

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -84,14 +84,16 @@ func (c *Compactor) writeToOutputFile(inputFiles []*compactionInputFile, filenam
 
 	// Generate output header.
 	hdr := Header{
-		Version:   Version,
-		PageSize:  inputFiles[0].hdr.PageSize,
-		PageN:     pageN,
-		Commit:    inputFiles[len(inputFiles)-1].hdr.Commit,
-		DBID:      inputFiles[0].hdr.DBID,
-		MinTXID:   inputFiles[0].hdr.MinTXID,
-		MaxTXID:   inputFiles[len(inputFiles)-1].hdr.MaxTXID,
-		Timestamp: inputFiles[0].hdr.Timestamp,
+		Version:      Version,
+		PageSize:     inputFiles[0].hdr.PageSize,
+		PageN:        pageN,
+		Commit:       inputFiles[len(inputFiles)-1].hdr.Commit,
+		DBID:         inputFiles[0].hdr.DBID,
+		MinTXID:      inputFiles[0].hdr.MinTXID,
+		MaxTXID:      inputFiles[len(inputFiles)-1].hdr.MaxTXID,
+		Timestamp:    inputFiles[0].hdr.Timestamp,
+		PreChecksum:  inputFiles[0].hdr.PreChecksum,
+		PostChecksum: inputFiles[len(inputFiles)-1].hdr.PostChecksum,
 	}
 
 	// Determine event info if events are included in the output file.

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -15,14 +15,16 @@ func TestCompactor_Compact(t *testing.T) {
 		dir := t.TempDir()
 		input := &ltx.FileSpec{
 			Header: ltx.Header{
-				Version:   1,
-				PageSize:  512,
-				PageN:     1,
-				Commit:    1,
-				DBID:      1,
-				MinTXID:   1,
-				MaxTXID:   1,
-				Timestamp: 1000,
+				Version:      1,
+				PageSize:     512,
+				PageN:        1,
+				Commit:       1,
+				DBID:         1,
+				MinTXID:      1,
+				MaxTXID:      1,
+				Timestamp:    1000,
+				PreChecksum:  0,
+				PostChecksum: ltx.PageChecksumFlag | 1,
 			},
 			PageHeaders: []ltx.PageHeader{
 				{
@@ -50,7 +52,7 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("SnapshotPageDataOnly", func(t *testing.T) {
 		spec, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 					{Pgno: 2},
@@ -63,7 +65,7 @@ func TestCompactor_Compact(t *testing.T) {
 				},
 			},
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 3, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 2000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 3, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 2000, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 					{Pgno: 3},
@@ -79,7 +81,7 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 
 		assertFileSpecEqual(t, spec, &ltx.FileSpec{
-			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
+			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 2},
 			PageHeaders: []ltx.PageHeader{
 				{Pgno: 1},
 				{Pgno: 2},
@@ -95,7 +97,7 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("NonSnapshotPageDataOnly", func(t *testing.T) {
 		spec, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 3, DBID: 1, MinTXID: 2, MaxTXID: 3, Timestamp: 1000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 3, DBID: 1, MinTXID: 2, MaxTXID: 3, Timestamp: 1000, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 3},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 3},
 				},
@@ -104,7 +106,7 @@ func TestCompactor_Compact(t *testing.T) {
 				},
 			},
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 3, DBID: 1, MinTXID: 4, MaxTXID: 5, Timestamp: 2000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 3, DBID: 1, MinTXID: 4, MaxTXID: 5, Timestamp: 2000, PreChecksum: ltx.PageChecksumFlag | 4, PostChecksum: ltx.PageChecksumFlag | 5},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 				},
@@ -113,7 +115,7 @@ func TestCompactor_Compact(t *testing.T) {
 				},
 			},
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 5, DBID: 1, MinTXID: 6, MaxTXID: 9, Timestamp: 3000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 5, DBID: 1, MinTXID: 6, MaxTXID: 9, Timestamp: 3000, PreChecksum: ltx.PageChecksumFlag | 6, PostChecksum: ltx.PageChecksumFlag | 9},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 2},
 					{Pgno: 3},
@@ -131,7 +133,7 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 
 		assertFileSpecEqual(t, spec, &ltx.FileSpec{
-			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 4, Commit: 5, DBID: 1, MinTXID: 2, MaxTXID: 9, Timestamp: 1000},
+			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 4, Commit: 5, DBID: 1, MinTXID: 2, MaxTXID: 9, Timestamp: 1000, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 9},
 			PageHeaders: []ltx.PageHeader{
 				{Pgno: 1},
 				{Pgno: 2},
@@ -161,6 +163,7 @@ func TestCompactor_Compact(t *testing.T) {
 				MinTXID:       1,
 				MaxTXID:       1,
 				Timestamp:     1000,
+				PostChecksum:  ltx.PageChecksumFlag | 1,
 			},
 			PageHeaders: []ltx.PageHeader{{Pgno: 1,
 				Nonce: [12]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7},
@@ -193,7 +196,7 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("MultiFileWithPageAndEventData", func(t *testing.T) {
 		spec, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 2, EventDataSize: 130, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 2, EventDataSize: 130, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 				},
@@ -210,7 +213,7 @@ func TestCompactor_Compact(t *testing.T) {
 				},
 			},
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 2000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 2000, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 				},
@@ -219,7 +222,7 @@ func TestCompactor_Compact(t *testing.T) {
 				},
 			},
 			&ltx.FileSpec{
-				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 1, EventDataSize: 80, Commit: 1, DBID: 1, MinTXID: 3, MaxTXID: 3, Timestamp: 3000},
+				Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 1, EventDataSize: 80, Commit: 1, DBID: 1, MinTXID: 3, MaxTXID: 3, Timestamp: 3000, PreChecksum: ltx.PageChecksumFlag | 3, PostChecksum: ltx.PageChecksumFlag | 3},
 				PageHeaders: []ltx.PageHeader{
 					{Pgno: 1},
 				},
@@ -239,7 +242,7 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 
 		assertFileSpecEqual(t, spec, &ltx.FileSpec{
-			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 3, EventDataSize: 210, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 3, Timestamp: 1000},
+			Header: ltx.Header{Version: 1, PageSize: 1024, PageN: 1, EventN: 3, EventDataSize: 210, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 3, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 3},
 			PageHeaders: []ltx.PageHeader{
 				{Pgno: 1},
 			},
@@ -277,12 +280,12 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("ErrDBIDMismatch", func(t *testing.T) {
 		_, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x81}, 1024)},
 			},
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 2, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 2, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x91}, 1024)},
 			},
@@ -294,12 +297,12 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("ErrPageSizeMismatch", func(t *testing.T) {
 		_, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 512, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 512, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x81}, 512)},
 			},
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 1},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x91}, 1024)},
 			},
@@ -311,12 +314,12 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("ErrNonContiguousTXID", func(t *testing.T) {
 		_, err := compactFileSpecs(t, ltx.NewCompactor(),
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 2},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x81}, 1024)},
 			},
 			&ltx.FileSpec{
-				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 1000},
+				Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 2, MaxTXID: 2, Timestamp: 1000, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2},
 				PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 				PageData:    [][]byte{bytes.Repeat([]byte{0x91}, 1024)},
 			},
@@ -328,7 +331,7 @@ func TestCompactor_Compact(t *testing.T) {
 	t.Run("ErrCannotCreateOutputFile", func(t *testing.T) {
 		dir := t.TempDir()
 		writeFileSpec(t, filepath.Join(dir, "input"), &ltx.FileSpec{
-			Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
+			Header:      ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 2, Timestamp: 1000, PostChecksum: ltx.PageChecksumFlag | 2},
 			PageHeaders: []ltx.PageHeader{{Pgno: 1}},
 			PageData:    [][]byte{bytes.Repeat([]byte{0x81}, 1024)},
 		})

--- a/header_block_reader_test.go
+++ b/header_block_reader_test.go
@@ -24,6 +24,7 @@ func TestHeaderBlockReader(t *testing.T) {
 				MinTXID:       1,
 				MaxTXID:       1,
 				Timestamp:     1000,
+				PostChecksum:  ltx.PageChecksumFlag | 1,
 			},
 			EventHeaders: []ltx.EventHeader{
 				{

--- a/header_block_writer_test.go
+++ b/header_block_writer_test.go
@@ -20,14 +20,16 @@ func TestHeaderBlockWriter(t *testing.T) {
 
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
 		if err := w.WriteHeader(ltx.Header{
-			Version:   1,
-			PageSize:  4096,
-			PageN:     2,
-			Commit:    3,
-			DBID:      4,
-			MinTXID:   5,
-			MaxTXID:   6,
-			Timestamp: 2000,
+			Version:      1,
+			PageSize:     4096,
+			PageN:        2,
+			Commit:       3,
+			DBID:         4,
+			MinTXID:      5,
+			MaxTXID:      6,
+			Timestamp:    2000,
+			PreChecksum:  ltx.PageChecksumFlag | 5,
+			PostChecksum: ltx.PageChecksumFlag | 6,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -72,6 +74,8 @@ func TestHeaderBlockWriter(t *testing.T) {
 			MinTXID:       2,
 			MaxTXID:       2,
 			Timestamp:     1000,
+			PreChecksum:   ltx.PageChecksumFlag | 2,
+			PostChecksum:  ltx.PageChecksumFlag | 2,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -116,12 +120,13 @@ func TestHeaderBlockWriter(t *testing.T) {
 	t.Run("ErrNoPageData", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
 		if err := w.WriteHeader(ltx.Header{
-			Version:  1,
-			PageSize: 1024,
-			PageN:    0,
-			Commit:   3,
-			MinTXID:  1,
-			MaxTXID:  1,
+			Version:      1,
+			PageSize:     1024,
+			PageN:        0,
+			Commit:       3,
+			MinTXID:      1,
+			MaxTXID:      1,
+			PostChecksum: ltx.PageChecksumFlag | 1,
 		}); err == nil || err.Error() != `page count required` {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -148,7 +153,7 @@ func TestHeaderBlockWriter_Close(t *testing.T) {
 		}
 
 		w := ltx.NewHeaderBlockWriter(ws)
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)
@@ -177,7 +182,7 @@ func TestHeaderBlockWriter_Close(t *testing.T) {
 		}
 
 		w := ltx.NewHeaderBlockWriter(ws)
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)
@@ -190,7 +195,7 @@ func TestHeaderBlockWriter_Close(t *testing.T) {
 
 	t.Run("ErrClosed", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)
@@ -214,7 +219,7 @@ func TestHeaderBlockWriter_Close(t *testing.T) {
 func TestHeaderBlockWriter_WriteHeader(t *testing.T) {
 	t.Run("ErrInvalidState", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		}
 		if err := w.WriteHeader(ltx.Header{}); err == nil || err.Error() != `cannot write header frame, expected page header` {
@@ -234,7 +239,7 @@ func TestHeaderBlockWriter_WriteHeader(t *testing.T) {
 		}
 
 		w := ltx.NewHeaderBlockWriter(ws)
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		}
 		if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err == nil || err.Error() != `write: marker` {
@@ -253,7 +258,7 @@ func TestHeaderBlockWriter_WriteEventHeader(t *testing.T) {
 
 	t.Run("ErrSizeRequired", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, EventN: 1, PageN: 1, Commit: 1, EventDataSize: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, EventN: 1, PageN: 1, Commit: 1, EventDataSize: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)
@@ -273,7 +278,7 @@ func TestHeaderBlockWriter_WritePageHeader(t *testing.T) {
 
 	t.Run("ErrPageNumberRequired", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 1, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 0}); err == nil || err.Error() != `page number required` {
 			t.Fatalf("unexpected error: %s", err)
@@ -282,7 +287,7 @@ func TestHeaderBlockWriter_WritePageHeader(t *testing.T) {
 
 	t.Run("ErrPageNumberOutOfBounds", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 4, DBID: 1, MinTXID: 2, MaxTXID: 2}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 1, Commit: 4, DBID: 1, MinTXID: 2, MaxTXID: 2, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 5}); err == nil || err.Error() != `page number 5 out-of-bounds for commit size 4` {
 			t.Fatalf("unexpected error: %s", err)
@@ -291,7 +296,7 @@ func TestHeaderBlockWriter_WritePageHeader(t *testing.T) {
 
 	t.Run("ErrSnapshotInitialPage", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 2, DBID: 1, MinTXID: 1, MaxTXID: 2}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 2, DBID: 1, MinTXID: 1, MaxTXID: 2, PostChecksum: ltx.PageChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 2}); err == nil || err.Error() != `snapshot transaction file must start with page number 1` {
 			t.Fatalf("unexpected error: %s", err)
@@ -300,7 +305,7 @@ func TestHeaderBlockWriter_WritePageHeader(t *testing.T) {
 
 	t.Run("ErrSnapshotNonsequentialPages", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 3, Commit: 3, DBID: 1, MinTXID: 1, MaxTXID: 1, PostChecksum: ltx.PageChecksumFlag | 1}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)
@@ -311,7 +316,7 @@ func TestHeaderBlockWriter_WritePageHeader(t *testing.T) {
 
 	t.Run("ErrOutOfOrderPages", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 2, DBID: 1, MinTXID: 2, MaxTXID: 2}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, PageN: 2, Commit: 2, DBID: 1, MinTXID: 2, MaxTXID: 2, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 2}); err != nil {
 			t.Fatal(err)
@@ -331,7 +336,7 @@ func TestHeaderBlockWriter_WriteEventData(t *testing.T) {
 
 	t.Run("ErrSizeMismatch", func(t *testing.T) {
 		w := ltx.NewHeaderBlockWriter(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, EventN: 1, PageN: 1, Commit: 1, EventDataSize: 10, DBID: 1, MinTXID: 2, MaxTXID: 2}); err != nil {
+		if err := w.WriteHeader(ltx.Header{Version: 1, PageSize: 1024, EventN: 1, PageN: 1, Commit: 1, EventDataSize: 10, DBID: 1, MinTXID: 2, MaxTXID: 2, PreChecksum: ltx.PageChecksumFlag | 2, PostChecksum: ltx.PageChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		} else if err := w.WritePageHeader(ltx.PageHeader{Pgno: 1}); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Overview

This pull request adds two checksums to the LTX file header:

- `PreChecksum`: the state of the database before LTX file is applied
- `PostChecksum`: the state of the database after the LTX file is applied

These are used so that we can guarantee that we are applying an LTX file to an expected previous state. While collisions are possible, it's highly unlikely with 63-bit checksums and an associated transaction ID. It is the responsibility of the caller to calculate these checksums although there are some checks in the header validation.

## Checksum Calculation

The checksum is incremental in that we don't need to recalculate the entire database on every transaction. We only need to "unapply" the checksum from the removed pages and "apply" the new checksum of the added/updated pages. This is done by using `XOR` and page-level checksums.

The following pseudocode illustrated:

```
VAR chksum uint64 = 0

# Apply checksums for each page
FOR EACH (pgno, data) IN added_pages
	chksum = chksum XOR page_checksum(pgno, data)
END

# Remove checksum for old page data; apply checksum for new page data
FOR EACH (pgno, prev_data, new_data) IN updated_pages
	chksum = chksum XOR page_checksum(pgno, prev_data)
	chksum = chksum XOR page_checksum(pgno, new_data)
END

# Remove checksum for removed pages
FOR EACH (pgno, data) IN removed_pages
	chksum = chksum XOR page_checksum(pgno, data)
END
```

The calculation of `page_checksum()` is simply:

```
CONST PAGE_CHECKSUM_MASK = (1 << 63) - 1

FUNCTION page_checksum(pgno uint32, data []byte) uint64 {
	RETURN CRC64(pgno, data) & PAGE_CHECKSUM_MASK
}
```

We only use the lower 63 bits of the checksum so we can use the high bit as a flag to indicate that the checksum is set. This is to ensure that we don't accidentally forget to set the checksum on a file. 