### PR TITLE
Add VerifyingReader

### DIFF
--- a/ltx.go
+++ b/ltx.go
@@ -206,9 +206,12 @@ func (t *Trailer) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
+// MaxPageSize is the maximum allowed page size for SQLite.
+const MaxPageSize = 65536
+
 // IsValidPageSize returns true if sz is between 512 and 64K and a power of two.
 func IsValidPageSize(sz uint32) bool {
-	for i := uint32(512); i <= 65536; i *= 2 {
+	for i := uint32(512); i <= MaxPageSize; i *= 2 {
 		if sz == i {
 			return true
 		}

--- a/reader.go
+++ b/reader.go
@@ -1,6 +1,7 @@
 package ltx
 
 import (
+	"errors"
 	"fmt"
 	"hash"
 	"hash/crc64"
@@ -10,8 +11,6 @@ import (
 // Reader represents a reader of an LTX file.
 type Reader struct {
 	r io.Reader
-
-	lr io.LimitedReader
 
 	header  Header
 	trailer Trailer
@@ -25,7 +24,6 @@ type Reader struct {
 func NewReader(r io.Reader) *Reader {
 	return &Reader{
 		r:     r,
-		lr:    io.LimitedReader{R: r, N: 0},
 		state: stateHeader,
 		hash:  crc64.New(crc64.MakeTable(crc64.ISO)),
 	}
@@ -63,9 +61,8 @@ func (r *Reader) Close() error {
 
 	r.writeToHash(b[:TrailerChecksumOffset])
 
-	// Compare checksum with checksum in header.
+	// Compare checksum with checksum in trailer.
 	if chksum := r.Checksum(); chksum != r.trailer.FileChecksum {
-		println("dbg/chksum", chksum, r.trailer.FileChecksum)
 		return ErrChecksumMismatch
 	}
 
@@ -158,4 +155,149 @@ func (r *Reader) Verify() (Header, Trailer, error) {
 func (r *Reader) writeToHash(b []byte) {
 	_, _ = r.hash.Write(b)
 	r.n += int64(len(b))
+}
+
+// VerifyingReader is a passthrough that validates the contents of the underlying reader.
+type VerifyingReader struct {
+	r     io.Reader
+	state string
+
+	header  Header
+	trailer Trailer
+	hash    hash.Hash64
+}
+
+// NewVerifyingReader returns a new instance of VerifyingReader.
+func NewVerifyingReader(r io.Reader) *VerifyingReader {
+	return &VerifyingReader{
+		r:     r,
+		state: stateHeader,
+		hash:  crc64.New(crc64.MakeTable(crc64.ISO)),
+	}
+}
+
+// WriteTo implements io.WriterTo.
+// It prevents io.Copy() from using a small buffer when copying using io.ReaderFrom.
+func (r *VerifyingReader) WriteTo(dst io.Writer) (written int64, err error) {
+	buf := make([]byte, MaxPageSize+PageHeaderSize)
+
+	for {
+		nr, er := r.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw < 0 || nr < nw {
+				nw = 0
+				if ew == nil {
+					ew = errors.New("invalid write result")
+				}
+			}
+			written += int64(nw)
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er != nil {
+			if er != io.EOF {
+				err = er
+			}
+			break
+		}
+	}
+	return written, err
+}
+
+// Read reads bytes from the underlying reader into p.
+// Returns io.ErrShortBuffer if len(p) is less than the size of the page frame.
+func (r *VerifyingReader) Read(p []byte) (n int, err error) {
+	switch r.state {
+	case stateHeader:
+		return r.readHeader(p)
+	case statePage:
+		return r.readPage(p)
+	case stateClose:
+		return r.readTrailer(p)
+	default: // closed
+		return 0, io.EOF
+	}
+}
+
+func (r *VerifyingReader) readHeader(p []byte) (n int, err error) {
+	if len(p) < HeaderSize {
+		return 0, io.ErrShortBuffer
+	}
+
+	if n, err := io.ReadFull(r.r, p[:HeaderSize]); err != nil {
+		return n, err
+	} else if err := r.header.UnmarshalBinary(p[:HeaderSize]); err != nil {
+		return n, fmt.Errorf("unmarshal header: %w", err)
+	}
+
+	_, _ = r.hash.Write(p[:HeaderSize])
+	r.state = statePage
+
+	return HeaderSize, r.header.Validate()
+}
+
+func (r *VerifyingReader) readPage(p []byte) (n int, err error) {
+	pageFrameSize := int(PageHeaderSize + r.header.PageSize)
+	if len(p) < pageFrameSize {
+		return 0, io.ErrShortBuffer
+	}
+
+	if n, err = io.ReadFull(r.r, p[:PageHeaderSize]); err != nil {
+		return n, err
+	}
+	_, _ = r.hash.Write(p[:n])
+
+	var pageHeader PageHeader
+	if err := pageHeader.UnmarshalBinary(p); err != nil {
+		return n, fmt.Errorf("unmarshal page header: %w", err)
+	}
+	if pageHeader.IsZero() {
+		r.state = stateClose // end of page block
+		return n, nil
+	}
+	if err := pageHeader.Validate(); err != nil {
+		return n, err
+	}
+
+	// Read page data.
+	pData := p[PageHeaderSize:pageFrameSize]
+	if n, err := io.ReadFull(r.r, pData); err != nil {
+		return PageHeaderSize + n, err
+	}
+	_, _ = r.hash.Write(pData)
+
+	return pageFrameSize, nil
+}
+
+func (r *VerifyingReader) readTrailer(p []byte) (n int, err error) {
+	if len(p) < TrailerSize {
+		return 0, io.ErrShortBuffer
+	}
+
+	if n, err = io.ReadFull(r.r, p[:TrailerSize]); err != nil {
+		return n, err
+	}
+	_, _ = r.hash.Write(p[:TrailerChecksumOffset])
+
+	if err := r.trailer.UnmarshalBinary(p[:TrailerSize]); err != nil {
+		return n, fmt.Errorf("unmarshal trailer: %w", err)
+	}
+
+	// Compare checksum with checksum in trailer.
+	chksum := ChecksumFlag | r.hash.Sum64()
+	if chksum != r.trailer.FileChecksum {
+		return n, ErrChecksumMismatch
+	}
+
+	// Update state to mark as closed.
+	r.state = stateClosed
+
+	return n, nil
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -73,3 +73,122 @@ func TestReader(t *testing.T) {
 		}
 	})
 }
+
+func TestVerifyingReader(t *testing.T) {
+	// Build a simple LTX file that most tests can use.
+	var srcBuf bytes.Buffer
+	writeFileSpec(t, &srcBuf, &ltx.FileSpec{
+		Header: ltx.Header{
+			Version:   1,
+			PageSize:  1024,
+			Commit:    2,
+			DBID:      1,
+			MinTXID:   1,
+			MaxTXID:   1,
+			Timestamp: 1000,
+		},
+		Pages: []ltx.PageSpec{
+			{
+				Header: ltx.PageHeader{Pgno: 1},
+				Data:   bytes.Repeat([]byte("1"), 1024),
+			},
+			{
+				Header: ltx.PageHeader{Pgno: 2},
+				Data:   bytes.Repeat([]byte("2"), 1024),
+			},
+		},
+		Trailer: ltx.Trailer{
+			PostApplyChecksum: ltx.ChecksumFlag | 1,
+		},
+	})
+	src := srcBuf.Bytes()
+
+	t.Run("OK", func(t *testing.T) {
+		var dst bytes.Buffer
+		if n, err := io.Copy(&dst, ltx.NewVerifyingReader(bytes.NewReader(src))); err != nil {
+			t.Fatal(err)
+		} else if got, want := int(n), len(src); got != want {
+			t.Fatalf("n=%d, want %d", got, want)
+		} else if got, want := dst.Len(), len(src); got != want {
+			t.Fatalf("dst.Len()=%d, want %d", got, want)
+		}
+	})
+
+	t.Run("Header", func(t *testing.T) {
+		t.Run("ErrShortBuffer", func(t *testing.T) {
+			buf := make([]byte, 1028)
+			r := ltx.NewVerifyingReader(bytes.NewReader(src))
+			if _, err := r.Read(buf[:10]); err != io.ErrShortBuffer {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrUnexpectedEOF", func(t *testing.T) {
+			if _, err := io.Copy(io.Discard, ltx.NewVerifyingReader(bytes.NewReader(src[:10]))); err != io.ErrUnexpectedEOF {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrInvalidHeader", func(t *testing.T) {
+			r := ltx.NewVerifyingReader(
+				io.MultiReader(
+					bytes.NewReader(make([]byte, 4)),
+					bytes.NewReader(src[4:])),
+			)
+			if _, err := io.Copy(io.Discard, r); err == nil || err.Error() != `unmarshal header: invalid LTX file` {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	})
+
+	t.Run("Page", func(t *testing.T) {
+		t.Run("ErrShortBuffer", func(t *testing.T) {
+			buf := make([]byte, 1028)
+			r := ltx.NewVerifyingReader(bytes.NewReader(src))
+			if _, err := r.Read(buf[:ltx.HeaderSize]); err != nil {
+				t.Fatal(err)
+			} else if _, err := r.Read(buf[:10]); err != io.ErrShortBuffer {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrUnexpectedEOF/Header", func(t *testing.T) {
+			if _, err := io.Copy(io.Discard, ltx.NewVerifyingReader(bytes.NewReader(src[:ltx.HeaderSize+1]))); err != io.ErrUnexpectedEOF {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrUnexpectedEOF/Data", func(t *testing.T) {
+			if _, err := io.Copy(io.Discard, ltx.NewVerifyingReader(bytes.NewReader(src[:ltx.HeaderSize+ltx.PageHeaderSize+1]))); err != io.ErrUnexpectedEOF {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	})
+
+	t.Run("Trailer", func(t *testing.T) {
+		t.Run("ErrShortBuffer", func(t *testing.T) {
+			buf := make([]byte, 1028)
+			r := ltx.NewVerifyingReader(bytes.NewReader(src))
+			if _, err := r.Read(buf); err != nil {
+				t.Fatal(err)
+			} else if _, err := r.Read(buf); err != nil { // page 1
+				t.Fatal(err)
+			} else if _, err := r.Read(buf); err != nil { // page 2
+				t.Fatal(err)
+			} else if _, err := r.Read(buf); err != nil { // end of page block
+				t.Fatal(err)
+			} else if _, err := r.Read(buf[:1]); err != io.ErrShortBuffer {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrUnexpectedEOF", func(t *testing.T) {
+			if _, err := io.Copy(io.Discard, ltx.NewVerifyingReader(bytes.NewReader(src[:len(src)-1]))); err != io.ErrUnexpectedEOF {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+		t.Run("ErrChecksumMismatch", func(t *testing.T) {
+			other := make([]byte, len(src))
+			copy(other, src)
+			other[len(other)-1] = 0
+			if _, err := io.Copy(io.Discard, ltx.NewVerifyingReader(bytes.NewReader(other))); err != ltx.ErrChecksumMismatch {
+				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	})
+}


### PR DESCRIPTION
This pull request adds a `VerifyingReader` that is a passthrough `io.Reader` that verifies the integrity of the file at the same time. A future PR will rename the existing `ltx.Reader` to `ltx.Decoder` and rename the `VerifyingReader` to simply `Reader`.