### PR TITLE
Add LTX CLI

### DIFF
--- a/cmd/ltx/main.go
+++ b/cmd/ltx/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Build information.
+var (
+	Version = "dev"
+)
+
+func main() {
+	m := NewMain()
+	if err := m.Run(context.Background(), os.Args[1:]); err == flag.ErrHelp {
+		os.Exit(1)
+	} else if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+// Main represents the main program execution.
+type Main struct{}
+
+// NewMain returns a new instance of Main.
+func NewMain() *Main {
+	return &Main{}
+}
+
+// Run executes the program.
+func (m *Main) Run(ctx context.Context, args []string) (err error) {
+	// Extract command name.
+	var cmd string
+	if len(args) > 0 {
+		cmd, args = args[0], args[1:]
+	}
+
+	switch cmd {
+	case "dump":
+		return NewDumpCommand().Run(ctx, args)
+	case "verify":
+		return NewVerifyCommand().Run(ctx, args)
+	default:
+		if cmd == "" || cmd == "help" || strings.HasPrefix(cmd, "-") {
+			m.Usage()
+			return flag.ErrHelp
+		}
+		return fmt.Errorf("ltx %s: unknown command", cmd)
+	}
+}
+
+// Usage prints the help screen to STDOUT.
+func (m *Main) Usage() {
+	fmt.Println(`
+ltx is a command-line tool for inspecting LTX files.
+
+Usage:
+
+	ltx <command> [arguments]
+
+The commands are:
+
+	verify       reads & verifies checksums of a set of LTX files
+`[1:])
+}

--- a/cmd/ltx/verify.go
+++ b/cmd/ltx/verify.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/superfly/ltx"
+)
+
+// VerifyCommand represents a command to verify the integrity of LTX files.
+type VerifyCommand struct{}
+
+// NewVerifyCommand returns a new instance of VerifyCommand.
+func NewVerifyCommand() *VerifyCommand {
+	return &VerifyCommand{}
+}
+
+// Run executes the command.
+func (c *VerifyCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-verify", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The verify command reads one or more LTX files and verifies its integrity.
+
+Usage:
+
+	ltx verify PATH [PATH...]
+
+`[1:],
+		)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("at least one LTX file must be specified")
+	}
+
+	var okN, errorN int
+	for _, filename := range fs.Args() {
+		if err := c.verifyFile(ctx, filename); err != nil {
+			errorN++
+			fmt.Printf("%s: %s\n", filename, err)
+			continue
+		}
+
+		okN++
+	}
+
+	if errorN != 0 {
+		return fmt.Errorf("%d ok, %d invalid", okN, errorN)
+	}
+
+	fmt.Println("ok")
+	return nil
+}
+
+func (c *VerifyCommand) verifyFile(ctx context.Context, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	n, err := io.Copy(io.Discard, ltx.NewReader(f))
+	if err != nil {
+		return err
+	} else if int64(n) > fi.Size() {
+		return fmt.Errorf("contains %d bytes past end of LTX contents (%d bytes)", int64(n)-fi.Size(), fi.Size())
+	}
+
+	return nil
+}

--- a/ltx.go
+++ b/ltx.go
@@ -143,11 +143,8 @@ func (h *Header) MarshalBinary() ([]byte, error) {
 func (h *Header) UnmarshalBinary(b []byte) error {
 	if len(b) < HeaderSize {
 		return io.ErrShortBuffer
-	} else if string(b[0:4]) != Magic {
-		return ErrInvalidFile
 	}
 
-	h.Version = Version
 	h.Flags = binary.BigEndian.Uint32(b[4:])
 	h.PageSize = binary.BigEndian.Uint32(b[8:])
 	h.Commit = binary.BigEndian.Uint32(b[12:])
@@ -156,6 +153,11 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.MaxTXID = binary.BigEndian.Uint64(b[28:])
 	h.Timestamp = binary.BigEndian.Uint64(b[36:])
 	h.PreApplyChecksum = binary.BigEndian.Uint64(b[44:])
+
+	if string(b[0:4]) != Magic {
+		return ErrInvalidFile
+	}
+	h.Version = Version
 
 	return nil
 }


### PR DESCRIPTION
This pull request adds an `ltx` command-line tool for inspecting & verifying LTX files. It currently includes two commands:

- `ltx dump` - Write the header, page headers, & trailer of an LTX file
- `ltx verify` - Reads one or more LTX files, verifies their contents and checksums
