### PR TITLE
Add 'checksum' command to CLI

### DIFF
--- a/cmd/ltx/checksum.go
+++ b/cmd/ltx/checksum.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/superfly/ltx"
+)
+
+// ChecksumCommand represents a command to compute the LTX checksum of a database file.
+type ChecksumCommand struct{}
+
+// NewChecksumCommand returns a new instance of ChecksumCommand.
+func NewChecksumCommand() *ChecksumCommand {
+	return &ChecksumCommand{}
+}
+
+// Run executes the command.
+func (c *ChecksumCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-checksum", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The checksum command computes the LTX checksum for a database file.
+
+Usage:
+
+	ltx checksum PATH
+`[1:],
+		)
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		fs.Usage()
+		return flag.ErrHelp
+	} else if fs.NArg() > 1 {
+		return fmt.Errorf("too many arguments")
+	}
+
+	f, err := os.Open(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Read database header to determine page size.
+	buf := make([]byte, 100)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return err
+	}
+	pageSize := int(binary.BigEndian.Uint16(buf[16:18]))
+	if pageSize == 1 {
+		pageSize = 65536
+	}
+
+	// Reseek to beginning and compute checksum.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	chksum, err := ltx.ChecksumReader(f, pageSize)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%016x\n", chksum)
+	return nil
+}

--- a/cmd/ltx/main.go
+++ b/cmd/ltx/main.go
@@ -40,6 +40,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	switch cmd {
+	case "checksum":
+		return NewChecksumCommand().Run(ctx, args)
 	case "dump":
 		return NewDumpCommand().Run(ctx, args)
 	case "verify":
@@ -64,6 +66,8 @@ Usage:
 
 The commands are:
 
+	checksum     computes the LTX checksum of a database file
+	dump         writes out metadata and page headers for a set of LTX files
 	verify       reads & verifies checksums of a set of LTX files
 `[1:])
 }


### PR DESCRIPTION
This command computes the LTX checksum of a single database file. This can be used for debugging a checksum mismatch between the database file and the last LTX file.

## Usage

Running against a single database:

```sh
$ ltx checksum my.db
fe13f1d0a5d4d2f4
```

Providing no arguments shows the help:

```sh
$ ltx checksum
The checksum command computes the LTX checksum for a database file.

Usage:

	ltx checksum PATH
```

Providing more than one arguments returns an error:

```sh
$ ltx checksum my.db other.db 
too many arguments
```