### PR TITLE
Add 'list' command

### DIFF
--- a/cmd/ltx/list.go
+++ b/cmd/ltx/list.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/superfly/ltx"
+)
+
+// ListCommand represents a command to print the header/trailer of one or more
+// LTX files in a table.
+type ListCommand struct{}
+
+// NewListCommand returns a new instance of ListCommand.
+func NewListCommand() *ListCommand {
+	return &ListCommand{}
+}
+
+// Run executes the command.
+func (c *ListCommand) Run(ctx context.Context, args []string) (ret error) {
+	fs := flag.NewFlagSet("ltx-list", flag.ContinueOnError)
+	fs.Usage = func() {
+		fmt.Println(`
+The list command lists header & trailer information for a set of LTX files.
+
+Usage:
+
+	ltx list [arguments] PATH [PATH...]
+
+Arguments:
+
+`[1:])
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	} else if fs.NArg() == 0 {
+		return fmt.Errorf("at least one LTX file is required")
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, "min_txid\tmax_txid\tpages\tpreapply\tpostapply\ttimestamp")
+	for _, arg := range fs.Args() {
+		if err := c.printFile(w, arg); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *ListCommand) printFile(w *tabwriter.Writer, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	r := ltx.NewReader(f)
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return err
+	}
+
+	// Only show timestamp if it is actually set.
+	timestamp := time.Unix(int64(r.Header().Timestamp), 0).UTC().Format(time.RFC3339)
+	if r.Header().Timestamp == 0 {
+		timestamp = ""
+	}
+
+	fmt.Fprintf(w, "%s\t%s\t%d\t%016x\t%016x\t%s\n",
+		ltx.FormatTXID(r.Header().MinTXID),
+		ltx.FormatTXID(r.Header().MaxTXID),
+		r.PageN(),
+		r.Header().PreApplyChecksum,
+		r.Trailer().PostApplyChecksum,
+		timestamp,
+	)
+
+	return nil
+}

--- a/cmd/ltx/main.go
+++ b/cmd/ltx/main.go
@@ -45,6 +45,8 @@ func (m *Main) Run(ctx context.Context, args []string) (err error) {
 		return NewChecksumCommand().Run(ctx, args)
 	case "dump":
 		return NewDumpCommand().Run(ctx, args)
+	case "list":
+		return NewListCommand().Run(ctx, args)
 	case "verify":
 		return NewVerifyCommand().Run(ctx, args)
 	case "version":

--- a/reader.go
+++ b/reader.go
@@ -16,6 +16,7 @@ type Reader struct {
 
 	header  Header
 	trailer Trailer
+	pageN   int
 	hash    hash.Hash64
 }
 
@@ -33,6 +34,9 @@ func (r *Reader) Header() Header { return r.header }
 
 // Trailer returns a copy of the trailer. Available after Close().
 func (r *Reader) Trailer() Trailer { return r.trailer }
+
+// PageN returns the number of pages read from the underlying LTX file.
+func (r *Reader) PageN() int { return r.pageN }
 
 // PeekHeader reads the header into a buffer and allows the caller to inspect it.
 func (r *Reader) PeekHeader() error {
@@ -120,6 +124,7 @@ func (r *Reader) readPage(p []byte) (n int, err error) {
 		return PageHeaderSize + n, err
 	}
 	_, _ = r.hash.Write(pData)
+	r.pageN++
 
 	return pageFrameSize, nil
 }


### PR DESCRIPTION
This command lists out header & trailer fields as well as page count for a set of LTX files.

```
$ ltx list *.ltx
min_txid          max_txid          pages  preapply          postapply         timestamp
00000000000be309  00000000000be309  1      f568301e5d0d3e74  df12f82318e4f87b  
00000000000be30a  00000000000be30a  1      df12f82318e4f87b  c4ffb2e6ee0f1913  
00000000000be30b  00000000000be30b  1      c4ffb2e6ee0f1913  fd18d667e8abd895  
00000000000be30c  00000000000be30c  1      fd18d667e8abd895  ecab7662d2960ddf  
00000000000be30d  00000000000be30d  1      ecab7662d2960ddf  98dac850a1a35f17  
```