### PR TITLE
Add WAL fields to CLI

### DIFF
--- a/cmd/ltx/dump.go
+++ b/cmd/ltx/dump.go
@@ -63,6 +63,9 @@ Arguments:
 	fmt.Printf("Max TXID:  %s (%d)\n", ltx.FormatTXID(hdr.MaxTXID), hdr.MaxTXID)
 	fmt.Printf("Timestamp: %s (%d)\n", time.UnixMilli(int64(hdr.Timestamp)).UTC().Format(time.RFC3339Nano), hdr.Timestamp)
 	fmt.Printf("Pre-apply: %016x\n", hdr.PreApplyChecksum)
+	fmt.Printf("WAL offset: %d\n", hdr.WALOffset)
+	fmt.Printf("WAL size:   %d\n", hdr.WALSize)
+	fmt.Printf("WAL salt:   %08x %08x\n", hdr.WALSalt1, hdr.WALSalt2)
 	fmt.Printf("\n")
 	if err != nil {
 		return err

--- a/cmd/ltx/list.go
+++ b/cmd/ltx/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"text/tabwriter"
 	"time"
@@ -23,6 +24,7 @@ func NewListCommand() *ListCommand {
 // Run executes the command.
 func (c *ListCommand) Run(ctx context.Context, args []string) (ret error) {
 	fs := flag.NewFlagSet("ltx-list", flag.ContinueOnError)
+	tsv := fs.Bool("tsv", false, "output as tab-separated values")
 	fs.Usage = func() {
 		fmt.Println(`
 The list command lists header & trailer information for a set of LTX files.
@@ -42,10 +44,14 @@ Arguments:
 		return fmt.Errorf("at least one LTX file is required")
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-	defer w.Flush()
+	var w io.Writer = os.Stdout
+	if !*tsv {
+		tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+		defer tw.Flush()
+		w = tw
+	}
 
-	fmt.Fprintln(w, "min_txid\tmax_txid\tcommit\tpages\tpreapply\tpostapply\ttimestamp")
+	fmt.Fprintln(w, "min_txid\tmax_txid\tcommit\tpages\tpreapply\tpostapply\ttimestamp\twal_offset\twal_size\twal_salt")
 	for _, arg := range fs.Args() {
 		if err := c.printFile(w, arg); err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
@@ -55,7 +61,7 @@ Arguments:
 	return nil
 }
 
-func (c *ListCommand) printFile(w *tabwriter.Writer, filename string) error {
+func (c *ListCommand) printFile(w io.Writer, filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -68,12 +74,12 @@ func (c *ListCommand) printFile(w *tabwriter.Writer, filename string) error {
 	}
 
 	// Only show timestamp if it is actually set.
-	timestamp := time.UnixMilli(int64(dec.Header().Timestamp)).UTC().Format(time.RFC3339Nano)
+	timestamp := time.UnixMilli(dec.Header().Timestamp).UTC().Format(time.RFC3339)
 	if dec.Header().Timestamp == 0 {
 		timestamp = ""
 	}
 
-	fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%016x\t%016x\t%s\n",
+	fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%016x\t%016x\t%s\t%d\t%d\t%08x %08x\n",
 		ltx.FormatTXID(dec.Header().MinTXID),
 		ltx.FormatTXID(dec.Header().MaxTXID),
 		dec.Header().Commit,
@@ -81,6 +87,9 @@ func (c *ListCommand) printFile(w *tabwriter.Writer, filename string) error {
 		dec.Header().PreApplyChecksum,
 		dec.Trailer().PostApplyChecksum,
 		timestamp,
+		dec.Header().WALOffset,
+		dec.Header().WALSize,
+		dec.Header().WALSalt1, dec.Header().WALSalt2,
 	)
 
 	return nil


### PR DESCRIPTION
Adds WAL offset, size, & salts to `dump` and `list`. Also adds a `-tsv` option to `list` and fixes a timestamp formatting issue.