### PR TITLE
Add TXID type

### DIFF
--- a/cmd/ltx/checksum.go
+++ b/cmd/ltx/checksum.go
@@ -45,7 +45,7 @@ Usage:
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Read database header to determine page size.
 	buf := make([]byte, 100)

--- a/cmd/ltx/dump.go
+++ b/cmd/ltx/dump.go
@@ -47,7 +47,7 @@ Arguments:
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	dec := ltx.NewDecoder(f)
 
@@ -59,8 +59,8 @@ Arguments:
 	fmt.Printf("Flags:     0x%08x\n", hdr.Flags)
 	fmt.Printf("Page size: %d\n", hdr.PageSize)
 	fmt.Printf("Commit:    %d\n", hdr.Commit)
-	fmt.Printf("Min TXID:  %s (%d)\n", ltx.FormatTXID(hdr.MinTXID), hdr.MinTXID)
-	fmt.Printf("Max TXID:  %s (%d)\n", ltx.FormatTXID(hdr.MaxTXID), hdr.MaxTXID)
+	fmt.Printf("Min TXID:  %s (%d)\n", hdr.MinTXID.String(), hdr.MinTXID)
+	fmt.Printf("Max TXID:  %s (%d)\n", hdr.MaxTXID.String(), hdr.MaxTXID)
 	fmt.Printf("Timestamp: %s (%d)\n", time.UnixMilli(int64(hdr.Timestamp)).UTC().Format(time.RFC3339Nano), hdr.Timestamp)
 	fmt.Printf("Pre-apply: %016x\n", hdr.PreApplyChecksum)
 	fmt.Printf("WAL offset: %d\n", hdr.WALOffset)

--- a/cmd/ltx/list.go
+++ b/cmd/ltx/list.go
@@ -47,14 +47,14 @@ Arguments:
 	var w io.Writer = os.Stdout
 	if !*tsv {
 		tw := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
-		defer tw.Flush()
+		defer func() { _ = tw.Flush() }()
 		w = tw
 	}
 
-	fmt.Fprintln(w, "min_txid\tmax_txid\tcommit\tpages\tpreapply\tpostapply\ttimestamp\twal_offset\twal_size\twal_salt")
+	_, _ = fmt.Fprintln(w, "min_txid\tmax_txid\tcommit\tpages\tpreapply\tpostapply\ttimestamp\twal_offset\twal_size\twal_salt")
 	for _, arg := range fs.Args() {
 		if err := c.printFile(w, arg); err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
+			_, _ = fmt.Fprintf(os.Stderr, "%s: %s\n", arg, err)
 		}
 	}
 
@@ -66,7 +66,7 @@ func (c *ListCommand) printFile(w io.Writer, filename string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	dec := ltx.NewDecoder(f)
 	if err := dec.Verify(); err != nil {
@@ -79,9 +79,9 @@ func (c *ListCommand) printFile(w io.Writer, filename string) error {
 		timestamp = ""
 	}
 
-	fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%016x\t%016x\t%s\t%d\t%d\t%08x %08x\n",
-		ltx.FormatTXID(dec.Header().MinTXID),
-		ltx.FormatTXID(dec.Header().MaxTXID),
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%016x\t%016x\t%s\t%d\t%d\t%08x %08x\n",
+		dec.Header().MinTXID.String(),
+		dec.Header().MaxTXID.String(),
 		dec.Header().Commit,
 		dec.PageN(),
 		dec.Header().PreApplyChecksum,

--- a/cmd/ltx/verify.go
+++ b/cmd/ltx/verify.go
@@ -61,7 +61,7 @@ func (c *VerifyCommand) verifyFile(ctx context.Context, filename string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return ltx.NewDecoder(f).Verify()
 }

--- a/compactor.go
+++ b/compactor.go
@@ -51,8 +51,8 @@ func (c *Compactor) Compact(ctx context.Context) (retErr error) {
 		}
 		if prevHdr.MaxTXID+1 != hdr.MinTXID {
 			return fmt.Errorf("non-contiguous transaction ids in input files: (%s,%s) -> (%s,%s)",
-				FormatTXID(prevHdr.MinTXID), FormatTXID(prevHdr.MaxTXID),
-				FormatTXID(hdr.MinTXID), FormatTXID(hdr.MaxTXID),
+				prevHdr.MinTXID.String(), prevHdr.MaxTXID.String(),
+				hdr.MinTXID.String(), hdr.MaxTXID.String(),
 			)
 		}
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -123,8 +123,12 @@ func (enc *Encoder) EncodeHeader(hdr Header) error {
 	// Use a compressed writer for the body if LZ4 is enabled.
 	if enc.header.Flags&HeaderFlagCompressLZ4 != 0 {
 		zw := lz4.NewWriter(enc.underlying)
-		zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)) // minimize memory allocation
-		zw.Apply(lz4.CompressionLevelOption(lz4.Fast))
+		if err := zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)); err != nil { // minimize memory allocation
+			return fmt.Errorf("cannot set lz4 block size: %w", err)
+		}
+		if err := zw.Apply(lz4.CompressionLevelOption(lz4.Fast)); err != nil {
+			return fmt.Errorf("cannot set lz4 compression level: %w", err)
+		}
 		enc.w = zw
 	}
 


### PR DESCRIPTION
This type is specifically needed for JSON marshaling but is also helpful for distinguishing TXID types in the code. Also, fixed some `errcheck` and `staticcheck` issues while I was in there.