### PR TITLE
Add Decoder.DecodeDatabaseTo()

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -78,3 +78,46 @@ func testDecoder(t *testing.T, name string, flags uint32) {
 		}
 	})
 }
+
+func TestDecoder_DecodeDatabaseTo(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		spec := &ltx.FileSpec{
+			Header: ltx.Header{Version: 1, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte("2"), 512)},
+				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 512)},
+			},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1},
+		}
+
+		// Decode serialized LTX file.
+		var buf bytes.Buffer
+		writeFileSpec(t, &buf, spec)
+		dec := ltx.NewDecoder(&buf)
+
+		var out bytes.Buffer
+		if err := dec.DecodeDatabaseTo(&out); err != nil {
+			t.Fatal(err)
+		} else if got, want := out.Bytes(), append(bytes.Repeat([]byte("2"), 512), bytes.Repeat([]byte("3"), 512)...); !bytes.Equal(got, want) {
+			t.Fatal("output mismatch")
+		}
+	})
+
+	t.Run("ErrNonSnapshot", func(t *testing.T) {
+		spec := &ltx.FileSpec{
+			Header: ltx.Header{Version: 1, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, Timestamp: 1000, PreApplyChecksum: ltx.ChecksumFlag | 1},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 512)},
+			},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 1},
+		}
+
+		// Decode serialized LTX file.
+		var buf bytes.Buffer
+		writeFileSpec(t, &buf, spec)
+		dec := ltx.NewDecoder(&buf)
+		if err := dec.DecodeDatabaseTo(io.Discard); err == nil || err.Error() != `cannot decode non-snapshot LTX file to SQLite database` {
+			t.Fatal(err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request adds a helper function to `ltx.Decoder` to write out pages for a snapshot LTX file to a database file.