### PR TITLE
Add replication position helpers

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -45,6 +45,15 @@ func (dec *Decoder) Header() Header { return dec.header }
 // Trailer returns a copy of the trailer. File checksum available after Close().
 func (dec *Decoder) Trailer() Trailer { return dec.trailer }
 
+// PostApplyPos returns the replication position after underlying the LTX file is applied.
+// Only valid after successful Close().
+func (dec *Decoder) PostApplyPos() Pos {
+	return Pos{
+		TXID:              dec.header.MaxTXID,
+		PostApplyChecksum: dec.trailer.PostApplyChecksum,
+	}
+}
+
 // Close verifies the reader is at the end of the file and that the checksum matches.
 func (dec *Decoder) Close() error {
 	if dec.state == stateClosed {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -76,6 +76,13 @@ func testDecoder(t *testing.T, name string, flags uint32) {
 		if err := dec.Close(); err != nil {
 			t.Fatal(err)
 		}
+
+		if got, want := dec.Header().PreApplyPos(), (ltx.Pos{}); got != want {
+			t.Fatalf("PreApplyPos=%s, want %s", got, want)
+		}
+		if got, want := dec.PostApplyPos(), (ltx.Pos{1, ltx.ChecksumFlag | 1}); got != want {
+			t.Fatalf("PostApplyPos=%s, want %s", got, want)
+		}
 	})
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -43,6 +43,15 @@ func (enc *Encoder) Header() Header { return enc.header }
 // Trailer returns a copy of the trailer. File checksum available after Close().
 func (enc *Encoder) Trailer() Trailer { return enc.trailer }
 
+// PostApplyPos returns the replication position after underlying the LTX file is applied.
+// Only valid after successful Close().
+func (enc *Encoder) PostApplyPos() Pos {
+	return Pos{
+		TXID:              enc.header.MaxTXID,
+		PostApplyChecksum: enc.trailer.PostApplyChecksum,
+	}
+}
+
 // SetPostApplyChecksum sets the post-apply checksum of the database.
 // Must call before Close().
 func (enc *Encoder) SetPostApplyChecksum(chksum uint64) {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -49,6 +49,13 @@ func TestEncoder(t *testing.T) {
 		if err := enc.Close(); err != nil {
 			t.Fatal(err)
 		}
+
+		if got, want := enc.Header().PreApplyPos(), (ltx.Pos{4, ltx.ChecksumFlag | 5}); got != want {
+			t.Fatalf("PreApplyPos=%s, want %s", got, want)
+		}
+		if got, want := enc.PostApplyPos(), (ltx.Pos{6, ltx.ChecksumFlag | 6}); got != want {
+			t.Fatalf("PostApplyPos=%s, want %s", got, want)
+		}
 	})
 }
 

--- a/ltx.go
+++ b/ltx.go
@@ -265,6 +265,14 @@ func (h *Header) Validate() error {
 	return nil
 }
 
+// PreApplyPos returns the replication position before the LTX file is applies.
+func (h Header) PreApplyPos() Pos {
+	return Pos{
+		TXID:              h.MinTXID - 1,
+		PostApplyChecksum: h.PreApplyChecksum,
+	}
+}
+
 // MarshalBinary encodes h to a byte slice.
 func (h *Header) MarshalBinary() ([]byte, error) {
 	b := make([]byte, HeaderSize)


### PR DESCRIPTION
This pull request adds a few helper functions because it's common to compute these:

- `ltx.Header.PreApplyPos()`
- `ltx.Decoder.PostApplyPos()`
- `ltx.Encoder.PostApplyPos()`