### PR TITLE
Fix DecodeDatabaseTo() with lock page

### DIFF
--- a/ltx.go
+++ b/ltx.go
@@ -223,6 +223,11 @@ func (h *Header) IsSnapshot() bool {
 	return h.MinTXID == 1
 }
 
+// LockPgno returns the lock page number based on the header's page size.
+func (h *Header) LockPgno() uint32 {
+	return LockPgno(h.PageSize)
+}
+
 // Validate returns an error if h is invalid.
 func (h *Header) Validate() error {
 	if h.Version != Version {


### PR DESCRIPTION
This fixes an issue where databases larger than 1GB would not have the lock page properly handled. This caused the output database to shift all pages after 1GB and the resulting database was 1 page short.