### PR TITLE
Fix contiguous file check

### DIFF
--- a/ltx.go
+++ b/ltx.go
@@ -609,3 +609,9 @@ func (a FileInfoSlice) MaxTXID() TXID {
 	}
 	return a[len(a)-1].MaxTXID
 }
+
+// IsContiguous returns true if the transaction range is contiguous with the previous range.
+// This is used to validate that the transaction ranges are contiguous when rebuilding snapshots.
+func IsContiguous(prevMaxTXID, minTXID, maxTXID TXID) bool {
+	return minTXID <= prevMaxTXID+1 && maxTXID > prevMaxTXID
+}

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -670,6 +670,15 @@ func TestParseTimestamp(t *testing.T) {
 	}
 }
 
+func TestIsContiguous(t *testing.T) {
+	if !ltx.IsContiguous(0, 1, 10) {
+		t.Fatal("expected contiguous")
+	}
+	if !ltx.IsContiguous(11, 11, 12) {
+		t.Fatal("expected contiguous")
+	}
+}
+
 func BenchmarkChecksumPage(b *testing.B) {
 	for _, pageSize := range []int{512, 1024, 2048, 4096, 8192, 16384, 32768, 65536} {
 		b.Run(fmt.Sprint(pageSize), func(b *testing.B) {


### PR DESCRIPTION
This pull request changes the contiguous file check so it allows overlapping files and not just sequential files for compaction.