### PR TITLE
Implement per-page compression, page index

### DIFF
--- a/cmd/ltx/apply.go
+++ b/cmd/ltx/apply.go
@@ -66,7 +66,7 @@ Arguments:
 	return dbFile.Close()
 }
 
-func (c *ApplyCommand) applyLTXFile(ctx context.Context, dbFile *os.File, filename string) error {
+func (c *ApplyCommand) applyLTXFile(_ context.Context, dbFile *os.File, filename string) error {
 	ltxFile, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/cmd/ltx/encode_db.go
+++ b/cmd/ltx/encode_db.go
@@ -30,7 +30,6 @@ func NewEncodeDBCommand() *EncodeDBCommand {
 func (c *EncodeDBCommand) Run(ctx context.Context, args []string) (ret error) {
 	fs := flag.NewFlagSet("ltx-encode-db", flag.ContinueOnError)
 	outPath := fs.String("o", "", "output path")
-	compressed := fs.Bool("c", false, "compress database pages")
 	fs.Usage = func() {
 		fmt.Println(`
 The encode-db command encodes an SQLite database into an LTX file.
@@ -73,11 +72,10 @@ Arguments:
 
 	var flags uint32
 	var postApplyChecksum ltx.Checksum
-	if *compressed {
-		flags |= ltx.HeaderFlagCompressLZ4
+	enc, err := ltx.NewEncoder(out)
+	if err != nil {
+		return fmt.Errorf("create ltx encoder: %w", err)
 	}
-
-	enc := ltx.NewEncoder(out)
 	if err := enc.EncodeHeader(ltx.Header{
 		Version:   1,
 		Flags:     flags,

--- a/cmd/ltx/verify.go
+++ b/cmd/ltx/verify.go
@@ -56,7 +56,7 @@ Usage:
 	return nil
 }
 
-func (c *VerifyCommand) verifyFile(ctx context.Context, filename string) error {
+func (c *VerifyCommand) verifyFile(_ context.Context, filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/compactor.go
+++ b/compactor.go
@@ -21,16 +21,18 @@ type Compactor struct {
 }
 
 // NewCompactor returns a new instance of Compactor with default settings.
-func NewCompactor(w io.Writer, rdrs []io.Reader) *Compactor {
-	c := &Compactor{
-		enc: NewEncoder(w),
+func NewCompactor(w io.Writer, rdrs []io.Reader) (*Compactor, error) {
+	enc, err := NewEncoder(w)
+	if err != nil {
+		return nil, fmt.Errorf("create ltx encoder: %w", err)
 	}
 
+	c := &Compactor{enc: enc}
 	c.inputs = make([]*compactorInput, len(rdrs))
 	for i := range c.inputs {
 		c.inputs[i] = &compactorInput{dec: NewDecoder(rdrs[i])}
 	}
-	return c
+	return c, nil
 }
 
 // Header returns the LTX header of the compacted file. Only valid after successful Compact().

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -116,7 +116,7 @@ func TestCompactor_Compact(t *testing.T) {
 			},
 			Trailer: ltx.Trailer{
 				PostApplyChecksum: 0x8a249272ad9f7dea,
-				FileChecksum:      0xcaf341fe1e6cddfb,
+				FileChecksum:      0xae0ae2e4c2df6049,
 			},
 		})
 	})
@@ -198,7 +198,7 @@ func TestCompactor_Compact(t *testing.T) {
 			},
 			Trailer: ltx.Trailer{
 				PostApplyChecksum: ltx.ChecksumFlag | 9,
-				FileChecksum:      0xead633959f3c67a8,
+				FileChecksum:      0x8da4b823aca2e8d7,
 			},
 		})
 	})
@@ -239,7 +239,7 @@ func TestCompactor_Compact(t *testing.T) {
 			},
 			Trailer: ltx.Trailer{
 				PostApplyChecksum: ltx.ChecksumFlag | 5,
-				FileChecksum:      0xf688132c3904f118,
+				FileChecksum:      0xa6246dd737ab66ca,
 			},
 		})
 	})

--- a/decoder.go
+++ b/decoder.go
@@ -140,6 +140,12 @@ func (dec *Decoder) decodePageIndex(r io.ByteReader) error {
 		}
 	}
 
+	// Read size of page index.
+	var size uint64
+	if err := binary.Read(r.(io.Reader), binary.BigEndian, &size); err != nil {
+		return fmt.Errorf("read page index size: %w", err)
+	}
+
 	dec.pageIndex = pageIndex
 	return nil
 }

--- a/decoder.go
+++ b/decoder.go
@@ -79,6 +79,9 @@ func (dec *Decoder) Close() error {
 	}
 	remaining := bytes.NewReader(remainingBytes)
 
+	// Write everything but the file checksum to the hash.
+	dec.writeToHash(remainingBytes[:len(remainingBytes)-ChecksumSize])
+
 	// Read page index.
 	if err := dec.decodePageIndex(remaining); err != nil {
 		return fmt.Errorf("read page index: %w", err)
@@ -93,8 +96,6 @@ func (dec *Decoder) Close() error {
 	}
 
 	// TODO: Ensure last read page is equal to the commit for snapshot LTX files
-
-	dec.writeToHash(b[:TrailerChecksumOffset])
 
 	// Compare file checksum with checksum in trailer.
 	if chksum := ChecksumFlag | Checksum(dec.hash.Sum64()); chksum != dec.trailer.FileChecksum {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -10,78 +10,98 @@ import (
 )
 
 func TestDecoder(t *testing.T) {
-	testDecoder(t, "OK", 0)
-	testDecoder(t, "CompressLZ4", ltx.HeaderFlagCompressLZ4)
-}
+	spec := &ltx.FileSpec{
+		Header: ltx.Header{
+			Version:   2,
+			PageSize:  1024,
+			Commit:    2,
+			MinTXID:   1,
+			MaxTXID:   1,
+			Timestamp: 1000,
+		},
+		Pages: []ltx.PageSpec{
+			{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte("2"), 1024)},
+			{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 1024)},
+		},
+		Trailer: ltx.Trailer{PostApplyChecksum: 0xe1899b6d587aaaaa},
+	}
 
-func testDecoder(t *testing.T, name string, flags uint32) {
-	t.Run(name, func(t *testing.T) {
-		spec := &ltx.FileSpec{
-			Header: ltx.Header{
-				Version:   1,
-				Flags:     flags,
-				PageSize:  1024,
-				Commit:    2,
-				MinTXID:   1,
-				MaxTXID:   1,
-				Timestamp: 1000,
-			},
-			Pages: []ltx.PageSpec{
-				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte("2"), 1024)},
-				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 1024)},
-			},
-			Trailer: ltx.Trailer{PostApplyChecksum: 0xe1899b6d587aaaaa},
-		}
+	// Write spec to file.
+	var buf bytes.Buffer
+	writeFileSpec(t, &buf, spec)
+	fileSpecData := buf.Bytes()
 
-		// Write spec to file.
-		var buf bytes.Buffer
-		writeFileSpec(t, &buf, spec)
+	// Read and verify data matches spec.
+	dec := ltx.NewDecoder(&buf)
 
-		// Read and verify data matches spec.
-		dec := ltx.NewDecoder(&buf)
+	// Verify header.
+	if err := dec.DecodeHeader(); err != nil {
+		t.Fatal(err)
+	} else if got, want := dec.Header(), spec.Header; !reflect.DeepEqual(got, want) {
+		t.Fatalf("header mismatch:\ngot=%#v\nwant=%#v", got, want)
+	}
 
-		// Verify header.
-		if err := dec.DecodeHeader(); err != nil {
+	// Verify page headers.
+	for i := range spec.Pages {
+		var hdr ltx.PageHeader
+		data := make([]byte, 1024)
+		if err := dec.DecodePage(&hdr, data); err != nil {
 			t.Fatal(err)
-		} else if got, want := dec.Header(), spec.Header; !reflect.DeepEqual(got, want) {
-			t.Fatalf("header mismatch:\ngot=%#v\nwant=%#v", got, want)
+		} else if got, want := hdr, spec.Pages[i].Header; got != want {
+			t.Fatalf("page hdr mismatch:\ngot=%#v\nwant=%#v", got, want)
+		} else if got, want := data, spec.Pages[i].Data; !bytes.Equal(got, want) {
+			t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
 		}
+	}
 
-		// Verify page headers.
-		for i := range spec.Pages {
-			var hdr ltx.PageHeader
-			data := make([]byte, 1024)
-			if err := dec.DecodePage(&hdr, data); err != nil {
-				t.Fatal(err)
-			} else if got, want := hdr, spec.Pages[i].Header; got != want {
-				t.Fatalf("page hdr mismatch:\ngot=%#v\nwant=%#v", got, want)
-			} else if got, want := data, spec.Pages[i].Data; !bytes.Equal(got, want) {
-				t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
-			}
-		}
+	if err := dec.DecodePage(&ltx.PageHeader{}, make([]byte, 1024)); err != io.EOF {
+		t.Fatalf("expected page header eof, got: %s", err)
+	}
 
-		if err := dec.DecodePage(&ltx.PageHeader{}, make([]byte, 1024)); err != io.EOF {
-			t.Fatal("expected page header eof")
-		}
+	// Close reader to verify integrity.
+	if err := dec.Close(); err != nil {
+		t.Fatal(err)
+	}
 
-		// Close reader to verify integrity.
-		if err := dec.Close(); err != nil {
-			t.Fatal(err)
-		}
+	// Verify page index.
+	index := dec.PageIndex()
+	if got, want := index, map[uint32]ltx.PageIndexElem{
+		1: {Offset: 100, Size: 49},
+		2: {Offset: 149, Size: 49},
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("page index mismatch:\ngot=%#v\nwant=%#v", got, want)
+	}
 
-		if got, want := dec.Header().PreApplyPos(), (ltx.Pos{}); got != want {
-			t.Fatalf("PreApplyPos=%s, want %s", got, want)
-		}
-		if got, want := dec.PostApplyPos(), (ltx.Pos{1, 0xe1899b6d587aaaaa}); got != want {
-			t.Fatalf("PostApplyPos=%s, want %s", got, want)
-		}
-	})
+	// Read page 1 by offset.
+	if hdr, data, err := ltx.DecodePageData(fileSpecData[100:]); err != nil {
+		t.Fatal(err)
+	} else if got, want := hdr, (ltx.PageHeader{Pgno: 1}); got != want {
+		t.Fatalf("page header mismatch:\ngot=%#v\nwant=%#v", got, want)
+	} else if got, want := data, bytes.Repeat([]byte("2"), 1024); !bytes.Equal(got, want) {
+		t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
+	}
+
+	// Read page 2 by offset.
+	if hdr, data, err := ltx.DecodePageData(fileSpecData[149:]); err != nil {
+		t.Fatal(err)
+	} else if got, want := hdr, (ltx.PageHeader{Pgno: 2}); got != want {
+		t.Fatalf("page header mismatch:\ngot=%#v\nwant=%#v", got, want)
+	} else if got, want := data, bytes.Repeat([]byte("3"), 1024); !bytes.Equal(got, want) {
+		t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
+	}
+
+	if got, want := dec.Header().PreApplyPos(), (ltx.Pos{}); got != want {
+		t.Fatalf("PreApplyPos=%s, want %s", got, want)
+	}
+	if got, want := dec.PostApplyPos(), (ltx.Pos{1, 0xe1899b6d587aaaaa}); got != want {
+		t.Fatalf("PostApplyPos=%s, want %s", got, want)
+	}
 }
 
 func TestDecoder_Decode_CommitZero(t *testing.T) {
 	spec := &ltx.FileSpec{
 		Header: ltx.Header{
-			Version:   1,
+			Version:   2,
 			Flags:     0,
 			PageSize:  1024,
 			Commit:    0,
@@ -126,7 +146,7 @@ func TestDecoder_Decode_CommitZero(t *testing.T) {
 func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		spec := &ltx.FileSpec{
-			Header: ltx.Header{Version: 1, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
+			Header: ltx.Header{Version: 2, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 1, MaxTXID: 2, Timestamp: 1000},
 			Pages: []ltx.PageSpec{
 				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte("2"), 512)},
 				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 512)},
@@ -148,13 +168,20 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 	})
 
 	t.Run("WithLockPage", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("skipping in short mode")
+		}
+
 		lockPgno := ltx.LockPgno(4096)
 		commit := lockPgno + 10
 
 		var want bytes.Buffer
 		var buf bytes.Buffer
-		enc := ltx.NewEncoder(&buf)
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, Flags: 0, PageSize: 4096, Commit: commit, MinTXID: 1, MaxTXID: 2, Timestamp: 1000}); err != nil {
+		enc, err := ltx.NewEncoder(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, Flags: 0, PageSize: 4096, Commit: commit, MinTXID: 1, MaxTXID: 2, Timestamp: 1000}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -189,7 +216,7 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 
 	t.Run("ErrNonSnapshot", func(t *testing.T) {
 		spec := &ltx.FileSpec{
-			Header: ltx.Header{Version: 1, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, Timestamp: 1000, PreApplyChecksum: ltx.ChecksumFlag | 1},
+			Header: ltx.Header{Version: 2, Flags: 0, PageSize: 512, Commit: 2, MinTXID: 2, MaxTXID: 2, Timestamp: 1000, PreApplyChecksum: ltx.ChecksumFlag | 1},
 			Pages: []ltx.PageSpec{
 				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte("3"), 512)},
 			},

--- a/encoder.go
+++ b/encoder.go
@@ -135,6 +135,8 @@ func (enc *Encoder) Close() error {
 }
 
 func (enc *Encoder) encodePageIndex() error {
+	offset := enc.n
+
 	// Write elements in sorted page number order.
 	pgnos := make([]uint32, 0, len(enc.index))
 	for pgno := range enc.index {
@@ -162,6 +164,12 @@ func (enc *Encoder) encodePageIndex() error {
 	if _, err := enc.w.Write(buf[:binary.PutUvarint(buf, 0)]); err != nil {
 		return fmt.Errorf("write page index pgno: %w", err)
 	}
+
+	// Write size of page index.
+	if err := binary.Write(enc.w, binary.BigEndian, uint64(enc.n-offset)); err != nil {
+		return fmt.Errorf("write page index size: %w", err)
+	}
+
 	return nil
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -1,24 +1,29 @@
 package ltx
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"hash"
 	"hash/crc64"
 	"io"
+	"slices"
 
 	"github.com/pierrec/lz4/v4"
 )
 
-// Encoder implements a encoder for an LTX file.
+// Encoder implements an encoder for an LTX file.
 type Encoder struct {
-	underlying io.Writer // main writer
-	w          io.Writer // current writer (main or lz4 writer)
-	state      string
+	w     io.Writer   // main writer
+	zw    *lz4.Writer // compressed writer
+	state string
 
 	header  Header
 	trailer Trailer
+	buf     bytes.Buffer
 	hash    hash.Hash64
-	n       int64 // bytes written
+	index   map[uint32]PageIndexElem // page number to offset
+	n       int64                    // bytes written
 
 	// Track how many of each write has occurred to move state.
 	prevPgno     uint32
@@ -26,12 +31,25 @@ type Encoder struct {
 }
 
 // NewEncoder returns a new instance of Encoder.
-func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{
-		underlying: w,
-		w:          w,
-		state:      stateHeader,
+func NewEncoder(w io.Writer) (*Encoder, error) {
+	enc := &Encoder{
+		w:     w,
+		state: stateHeader,
+		index: make(map[uint32]PageIndexElem),
 	}
+
+	// The compressed writer writes to a buffer so we can calculate the size
+	// of the compressed data for the page index.
+	zw := lz4.NewWriter(&enc.buf)
+	if err := zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)); err != nil { // minimize memory allocation
+		return nil, fmt.Errorf("cannot set lz4 block size: %w", err)
+	}
+	if err := zw.Apply(lz4.CompressionLevelOption(lz4.Fast)); err != nil {
+		return nil, fmt.Errorf("cannot set lz4 compression level: %w", err)
+	}
+	enc.zw = zw
+
+	return enc, nil
 }
 
 // N returns the number of bytes written.
@@ -74,15 +92,15 @@ func (enc *Encoder) Close() error {
 		return fmt.Errorf("write empty page header: %w", err)
 	}
 
-	// Close the compressed writer, if in use.
-	if zw, ok := enc.w.(*lz4.Writer); ok {
-		if err := zw.Close(); err != nil {
-			return fmt.Errorf("cannot close lz4 writer: %w", err)
-		}
+	// Close the compressed writer.
+	if err := enc.zw.Close(); err != nil {
+		return fmt.Errorf("cannot close lz4 writer: %w", err)
 	}
 
-	// Revert to original writer now that we've passed the compressed body.
-	enc.w = enc.underlying
+	// Write index to file.
+	if err := enc.encodePageIndex(); err != nil {
+		return fmt.Errorf("write page index: %w", err)
+	}
 
 	// Marshal trailer to bytes.
 	b1, err := enc.trailer.MarshalBinary()
@@ -116,6 +134,37 @@ func (enc *Encoder) Close() error {
 	return nil
 }
 
+func (enc *Encoder) encodePageIndex() error {
+	// Write elements in sorted page number order.
+	pgnos := make([]uint32, 0, len(enc.index))
+	for pgno := range enc.index {
+		pgnos = append(pgnos, pgno)
+	}
+	slices.Sort(pgnos)
+
+	// Write each element as a varint-encoded tuple.
+	buf := make([]byte, binary.MaxVarintLen64)
+	for _, pgno := range pgnos {
+		elem := enc.index[pgno]
+
+		if _, err := enc.w.Write(buf[:binary.PutUvarint(buf, uint64(pgno))]); err != nil {
+			return fmt.Errorf("write page index pgno: %w", err)
+		}
+		if _, err := enc.w.Write(buf[:binary.PutUvarint(buf, uint64(elem.Offset))]); err != nil {
+			return fmt.Errorf("write page index offset: %w", err)
+		}
+		if _, err := enc.w.Write(buf[:binary.PutUvarint(buf, uint64(elem.Size))]); err != nil {
+			return fmt.Errorf("write page index size: %w", err)
+		}
+	}
+
+	// Write end marker.
+	if _, err := enc.w.Write(buf[:binary.PutUvarint(buf, 0)]); err != nil {
+		return fmt.Errorf("write page index pgno: %w", err)
+	}
+	return nil
+}
+
 // EncodeHeader writes hdr to the file's header block.
 func (enc *Encoder) EncodeHeader(hdr Header) error {
 	if enc.state == stateClosed {
@@ -137,18 +186,6 @@ func (enc *Encoder) EncodeHeader(hdr Header) error {
 		return fmt.Errorf("marshal header: %w", err)
 	} else if _, err := enc.write(b); err != nil {
 		return fmt.Errorf("write header: %w", err)
-	}
-
-	// Use a compressed writer for the body if LZ4 is enabled.
-	if enc.header.Flags&HeaderFlagCompressLZ4 != 0 {
-		zw := lz4.NewWriter(enc.underlying)
-		if err := zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)); err != nil { // minimize memory allocation
-			return fmt.Errorf("cannot set lz4 block size: %w", err)
-		}
-		if err := zw.Apply(lz4.CompressionLevelOption(lz4.Fast)); err != nil {
-			return fmt.Errorf("cannot set lz4 compression level: %w", err)
-		}
-		enc.w = zw
 	}
 
 	// Move writer state to write page headers.
@@ -196,6 +233,8 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 		}
 	}
 
+	offset := enc.n
+
 	// Encode & write header.
 	b, err := hdr.MarshalBinary()
 	if err != nil {
@@ -205,23 +244,61 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 	}
 
 	// Write data to file.
-	if _, err = enc.write(data); err != nil {
+	if _, err = enc.writeCompressed(data); err != nil {
 		return fmt.Errorf("write page data: %w", err)
 	}
 
 	enc.pagesWritten++
 	enc.prevPgno = hdr.Pgno
+	enc.index[hdr.Pgno] = PageIndexElem{
+		Offset: offset,
+		Size:   enc.n - offset,
+	}
+
 	return nil
 }
 
-// write to the current writer & add to the checksum.
+// write to the uncompressed writer & add to the checksum.
 func (enc *Encoder) write(b []byte) (n int, err error) {
 	n, err = enc.w.Write(b)
 	enc.writeToHash(b[:n])
 	return n, err
 }
 
+// write to the compressed writer & add to the checksum.
+// Returns the size of the compressed data.
+func (enc *Encoder) writeCompressed(b []byte) (n int, err error) {
+	// Reset the buffer & compressed writer.
+	enc.buf.Reset()
+	enc.zw.Reset(&enc.buf)
+
+	// Write to the compressed writer to the buffer and then write the buffer to the uncompressed writer.
+	// This is necessary so we can calculate the size of the compressed data for the page index.
+	if _, err = enc.zw.Write(b); err != nil {
+		return n, err
+	}
+
+	// Close the compressed writer to flush any remaining data.
+	if err := enc.zw.Close(); err != nil {
+		return n, fmt.Errorf("cannot close lz4 writer: %w", err)
+	}
+
+	compressed := enc.buf.Bytes()
+	n, err = enc.w.Write(compressed)
+
+	// Write the uncompressed data to the hash, but add the compressed length to the size.
+	_, _ = enc.hash.Write(b)
+	enc.n += int64(len(compressed))
+
+	return n, err
+}
+
 func (enc *Encoder) writeToHash(b []byte) {
 	_, _ = enc.hash.Write(b)
 	enc.n += int64(len(b))
+}
+
+type PageIndexElem struct {
+	Offset int64
+	Size   int64
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -17,9 +17,12 @@ func TestEncoder(t *testing.T) {
 		page1 := make([]byte, 4096)
 		rnd.Read(page1)
 
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := enc.EncodeHeader(ltx.Header{
-			Version:          1,
+			Version:          2,
 			PageSize:         4096,
 			Commit:           3,
 			MinTXID:          5,
@@ -60,9 +63,12 @@ func TestEncoder(t *testing.T) {
 
 	// Ensure encoder can generate LTX files with a zero commit and no pages.
 	t.Run("CommitZero", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := enc.EncodeHeader(ltx.Header{
-			Version:          1,
+			Version:          2,
 			PageSize:         4096,
 			Commit:           0,
 			MinTXID:          5,
@@ -88,8 +94,11 @@ func TestEncoder(t *testing.T) {
 
 	// Ensure encoder has an empty post-apply checksum when encoding a deletion file.
 	t.Run("ErrInvalidCommitZeroPostApplyChecksum", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 4096, Commit: 0, MinTXID: 5, MaxTXID: 6, Timestamp: 2000, PreApplyChecksum: ltx.ChecksumFlag | 5}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 4096, Commit: 0, MinTXID: 5, MaxTXID: 6, Timestamp: 2000, PreApplyChecksum: ltx.ChecksumFlag | 5}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -102,15 +111,21 @@ func TestEncoder(t *testing.T) {
 
 func TestEncode_Close(t *testing.T) {
 	t.Run("ErrInvalidState", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := enc.Close(); err == nil || err.Error() != `cannot close, expected header` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 
 	t.Run("ErrClosed", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		} else if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, make([]byte, 1024)); err != nil {
 			t.Fatal(err)
@@ -132,8 +147,11 @@ func TestEncode_Close(t *testing.T) {
 
 func TestEncode_EncodeHeader(t *testing.T) {
 	t.Run("ErrInvalidState", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		}
 		if err := enc.EncodeHeader(ltx.Header{}); err == nil || err.Error() != `cannot encode header frame, expected page` {
@@ -144,15 +162,21 @@ func TestEncode_EncodeHeader(t *testing.T) {
 
 func TestEncode_EncodePage(t *testing.T) {
 	t.Run("ErrInvalidState", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := enc.EncodePage(ltx.PageHeader{}, nil); err == nil || err.Error() != `cannot encode page header, expected header` {
 			t.Fatal(err)
 		}
 	})
 
 	t.Run("ErrPageNumberRequired", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 1, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		} else if err := enc.EncodePage(ltx.PageHeader{Pgno: 0}, nil); err == nil || err.Error() != `page number required` {
 			t.Fatalf("unexpected error: %s", err)
@@ -160,8 +184,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrPageNumberOutOfBounds", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		} else if err := enc.EncodePage(ltx.PageHeader{Pgno: 5}, nil); err == nil || err.Error() != `page number 5 out-of-bounds for commit size 4` {
 			t.Fatalf("unexpected error: %s", err)
@@ -169,8 +196,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrSnapshotInitialPage", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 2}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 2}); err != nil {
 			t.Fatal(err)
 		} else if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, make([]byte, 1024)); err == nil || err.Error() != `snapshot transaction file must start with page number 1` {
 			t.Fatalf("unexpected error: %s", err)
@@ -178,8 +208,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrSnapshotNonsequentialPages", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 3, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 3, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		}
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, make([]byte, 1024)); err != nil {
@@ -192,8 +225,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrCannotEncodeLockPage", func(t *testing.T) {
-		enc := ltx.NewEncoder(io.Discard)
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 4096, Commit: 262145, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(io.Discard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 4096, Commit: 262145, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -211,8 +247,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrSnapshotNonsequentialPagesAfterLockPage", func(t *testing.T) {
-		enc := ltx.NewEncoder(io.Discard)
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 4096, Commit: 262147, MinTXID: 1, MaxTXID: 1}); err != nil {
+		enc, err := ltx.NewEncoder(io.Discard)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 4096, Commit: 262147, MinTXID: 1, MaxTXID: 1}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -230,8 +269,11 @@ func TestEncode_EncodePage(t *testing.T) {
 	})
 
 	t.Run("ErrOutOfOrderPages", func(t *testing.T) {
-		enc := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
-		if err := enc.EncodeHeader(ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2}); err != nil {
+		enc, err := ltx.NewEncoder(createFile(t, filepath.Join(t.TempDir(), "ltx")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 2, MaxTXID: 2, PreApplyChecksum: ltx.ChecksumFlag | 2}); err != nil {
 			t.Fatal(err)
 		}
 		if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, make([]byte, 1024)); err != nil {

--- a/file_spec.go
+++ b/file_spec.go
@@ -15,7 +15,10 @@ type FileSpec struct {
 
 // Write encodes a file spec to a file.
 func (s *FileSpec) WriteTo(dst io.Writer) (n int64, err error) {
-	enc := NewEncoder(dst)
+	enc, err := NewEncoder(dst)
+	if err != nil {
+		return 0, fmt.Errorf("create ltx encoder: %w", err)
+	}
 	if err := enc.EncodeHeader(s.Header); err != nil {
 		return 0, fmt.Errorf("encode header: %s", err)
 	}

--- a/ltx.go
+++ b/ltx.go
@@ -20,7 +20,7 @@ const (
 	Magic = "LTX1"
 
 	// Version is the current version of the LTX file format.
-	Version = 1
+	Version = 2
 )
 
 // Size constants.
@@ -170,10 +170,9 @@ func (t *TXID) UnmarshalJSON(data []byte) (err error) {
 
 // Header flags.
 const (
-	HeaderFlagMask = uint32(HeaderFlagCompressLZ4 | HeaderFlagNoChecksum)
+	HeaderFlagMask = uint32(HeaderFlagNoChecksum)
 
-	HeaderFlagCompressLZ4 = uint32(1 << 0)
-	HeaderFlagNoChecksum  = uint32(1 << 1)
+	HeaderFlagNoChecksum = uint32(1 << 1)
 )
 
 // Header represents the header frame of an LTX file.

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -51,7 +51,7 @@ func TestParsePos(t *testing.T) {
 func TestHeader_Validate(t *testing.T) {
 	t.Run("OK", func(t *testing.T) {
 		hdr := ltx.Header{
-			Version:          1,
+			Version:          2,
 			PageSize:         1024,
 			Commit:           2,
 			MinTXID:          3,
@@ -68,7 +68,7 @@ func TestHeader_Validate(t *testing.T) {
 	})
 	t.Run("CommitZero", func(t *testing.T) {
 		hdr := ltx.Header{
-			Version:          1,
+			Version:          2,
 			PageSize:         1024,
 			Commit:           0,
 			MinTXID:          5,
@@ -86,73 +86,73 @@ func TestHeader_Validate(t *testing.T) {
 		}
 	})
 	t.Run("ErrFlags", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, Flags: 1 << 3}
+		hdr := ltx.Header{Version: 2, Flags: 1 << 3}
 		if err := hdr.Validate(); err == nil || err.Error() != `invalid flags: 0x00000008` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrInvalidPageSize", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1000}
+		hdr := ltx.Header{Version: 2, PageSize: 1000}
 		if err := hdr.Validate(); err == nil || err.Error() != `invalid page size: 1000` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrMinTXIDRequired", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2}
 		if err := hdr.Validate(); err == nil || err.Error() != `minimum transaction id required` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrMaxTXIDRequired", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 3}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 3}
 		if err := hdr.Validate(); err == nil || err.Error() != `maximum transaction id required` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrTXIDOutOfOrderRequired", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 3, MaxTXID: 2}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 3, MaxTXID: 2}
 		if err := hdr.Validate(); err == nil || err.Error() != `transaction ids out of order: (3,2)` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrNegativeWALOffset", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALOffset: -1000}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALOffset: -1000}
 		if err := hdr.Validate(); err == nil || err.Error() != `wal offset cannot be negative: -1000` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrNegativeWALSize", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALOffset: 32, WALSize: -1000}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALOffset: 32, WALSize: -1000}
 		if err := hdr.Validate(); err == nil || err.Error() != `wal size cannot be negative: -1000` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrWALOffsetRequiredWithWALSalt", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALSalt1: 100}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALSalt1: 100}
 		if err := hdr.Validate(); err == nil || err.Error() != `wal offset required if salt exists` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrWALOffsetRequiredWithWALSize", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALSize: 1000}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 2, MinTXID: 1, MaxTXID: 1, WALSize: 1000}
 		if err := hdr.Validate(); err == nil || err.Error() != `wal offset required if wal size exists` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrSnapshotPreApplyChecksumNotAllowed", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 4, MinTXID: 1, MaxTXID: 3, PreApplyChecksum: 1}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 4, MinTXID: 1, MaxTXID: 3, PreApplyChecksum: 1}
 		if err := hdr.Validate(); err == nil || err.Error() != `pre-apply checksum must be zero on snapshots` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrNonSnapshotPreApplyChecksumRequired", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 3}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 3}
 		if err := hdr.Validate(); err == nil || err.Error() != `pre-apply checksum required on non-snapshot files` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
 	t.Run("ErrInvalidPreApplyChecksumFormat", func(t *testing.T) {
-		hdr := ltx.Header{Version: 1, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 3, PreApplyChecksum: 1}
+		hdr := ltx.Header{Version: 2, PageSize: 1024, Commit: 4, MinTXID: 2, MaxTXID: 3, PreApplyChecksum: 1}
 		if err := hdr.Validate(); err == nil || err.Error() != `invalid pre-apply checksum format` {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -788,7 +788,10 @@ func compactFileSpecs(tb testing.TB, inputs ...*ltx.FileSpec) (*ltx.FileSpec, er
 
 	// Compact files together.
 	var output bytes.Buffer
-	c := ltx.NewCompactor(&output, rdrs)
+	c, err := ltx.NewCompactor(&output, rdrs)
+	if err != nil {
+		return nil, err
+	}
 	if err := c.Compact(context.Background()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request makes several backward incompatible changes to the LTX file format and bumps the `Version` number to `2`.

- Always compresses data (and there for removed the `CompressLZ4` flag)
- Compresses each page individually rather than compressing the entire page block.
- Writes an index to the trailer of the file so that clients can maintain an index of page locations without downloading the entire file.

These changes will allow us to run a read replica VFS that pulls page data directly from S3 rather than restoring a full snapshot first.