### PR TITLE
Add progress tracking to Compactor

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -13,6 +13,20 @@ type CompactorStatus struct {
 	Total uint32 // Total pages to compact (from Commit field)
 }
 
+// IsZero returns true if the status has not been initialized.
+func (s CompactorStatus) IsZero() bool {
+	return s.N == 0 && s.Total == 0
+}
+
+// Pct returns the percentage of compaction complete (0.0 to 1.0).
+// Returns 0 if Total is zero.
+func (s CompactorStatus) Pct() float64 {
+	if s.Total == 0 {
+		return 0
+	}
+	return float64(s.N) / float64(s.Total)
+}
+
 // Compactor represents a compactor of LTX files.
 type Compactor struct {
 	enc    *Encoder

--- a/compactor.go
+++ b/compactor.go
@@ -4,12 +4,22 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 )
+
+// CompactorStatus represents the current progress of compaction.
+type CompactorStatus struct {
+	N     uint32 // Last page number that was compacted
+	Total uint32 // Total pages to compact (from Commit field)
+}
 
 // Compactor represents a compactor of LTX files.
 type Compactor struct {
 	enc    *Encoder
 	inputs []*compactorInput
+
+	n     atomic.Uint32 // last page that was compacted
+	total atomic.Uint32 // total pages (from last input's Commit)
 
 	// These flags will be set when encoding the header.
 	HeaderFlags uint32
@@ -40,6 +50,15 @@ func (c *Compactor) Header() Header { return c.enc.Header() }
 
 // Trailer returns the LTX trailer of the compacted file. Only valid after successful Compact().
 func (c *Compactor) Trailer() Trailer { return c.enc.Trailer() }
+
+// Status returns the current compaction progress.
+// Safe to call concurrently from another goroutine.
+func (c *Compactor) Status() CompactorStatus {
+	return CompactorStatus{
+		N:     c.n.Load(),
+		Total: c.total.Load(),
+	}
+}
 
 // Compact merges the input readers into a single LTX writer.
 func (c *Compactor) Compact(ctx context.Context) (retErr error) {
@@ -88,6 +107,9 @@ func (c *Compactor) Compact(ctx context.Context) (retErr error) {
 		return fmt.Errorf("write header: %w", err)
 	}
 
+	// Set total page count for progress tracking.
+	c.total.Store(maxHdr.Commit)
+
 	// Write page headers & data.
 	if err := c.writePageBlock(ctx); err != nil {
 		return err
@@ -129,6 +151,9 @@ func (c *Compactor) writePageBlock(ctx context.Context) error {
 		if err := c.writePageBuffer(ctx, pgno); err != nil {
 			return err
 		}
+
+		// Update progress after each page is written.
+		c.n.Store(pgno)
 	}
 
 	return nil

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -311,4 +311,51 @@ func TestCompactor_Compact(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
+
+	t.Run("Status", func(t *testing.T) {
+		bufs := make([]bytes.Buffer, 2)
+		writeFileSpec(t, &bufs[0], &ltx.FileSpec{
+			Header: ltx.Header{Version: ltx.Version, PageSize: 1024, Commit: 3, MinTXID: 1, MaxTXID: 1, Timestamp: 1000},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{0x81}, 1024)},
+				{Header: ltx.PageHeader{Pgno: 2}, Data: bytes.Repeat([]byte{0x82}, 1024)},
+				{Header: ltx.PageHeader{Pgno: 3}, Data: bytes.Repeat([]byte{0x83}, 1024)},
+			},
+			Trailer: ltx.Trailer{PostApplyChecksum: 0x8a249272ad9f7dea},
+		})
+		writeFileSpec(t, &bufs[1], &ltx.FileSpec{
+			Header: ltx.Header{Version: ltx.Version, PageSize: 1024, Commit: 5, MinTXID: 2, MaxTXID: 2, Timestamp: 2000, PreApplyChecksum: 0x8a249272ad9f7dea},
+			Pages: []ltx.PageSpec{
+				{Header: ltx.PageHeader{Pgno: 1}, Data: bytes.Repeat([]byte{0x91}, 1024)},
+				{Header: ltx.PageHeader{Pgno: 4}, Data: bytes.Repeat([]byte{0x94}, 1024)},
+				{Header: ltx.PageHeader{Pgno: 5}, Data: bytes.Repeat([]byte{0x95}, 1024)},
+			},
+			Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumFlag | 2},
+		})
+
+		// Compact files together.
+		c, err := ltx.NewCompactor(io.Discard, []io.Reader{&bufs[0], &bufs[1]})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Status should be zero before compaction.
+		if got := c.Status(); got.N != 0 || got.Total != 0 {
+			t.Fatalf("expected zero status before compaction, got N=%d, Total=%d", got.N, got.Total)
+		}
+
+		if err := c.Compact(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+
+		// After compaction, Status should reflect progress.
+		status := c.Status()
+		if got, want := status.Total, uint32(5); got != want {
+			t.Fatalf("Status().Total=%d, want %d", got, want)
+		}
+		// N should be the last page that was written (page 5).
+		if got, want := status.N, uint32(5); got != want {
+			t.Fatalf("Status().N=%d, want %d", got, want)
+		}
+	})
 }

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -340,8 +340,12 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 
 		// Status should be zero before compaction.
-		if got := c.Status(); got.N != 0 || got.Total != 0 {
+		if got := c.Status(); !got.IsZero() {
 			t.Fatalf("expected zero status before compaction, got N=%d, Total=%d", got.N, got.Total)
+		}
+		// Pct should return 0 when Total is 0 (avoid divide by zero).
+		if got := c.Status().Pct(); got != 0 {
+			t.Fatalf("expected Pct()=0 before compaction, got %f", got)
 		}
 
 		if err := c.Compact(context.Background()); err != nil {
@@ -356,6 +360,10 @@ func TestCompactor_Compact(t *testing.T) {
 		// N should be the last page that was written (page 5).
 		if got, want := status.N, uint32(5); got != want {
 			t.Fatalf("Status().N=%d, want %d", got, want)
+		}
+		// Pct should return 1.0 when complete.
+		if got, want := status.Pct(), 1.0; got != want {
+			t.Fatalf("Status().Pct()=%f, want %f", got, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Add `CompactorStatus` struct with `N` (last page compacted) and `Total` (total pages from Commit field)
- Add `Status()` method that returns current progress, safe to call concurrently from another goroutine
- Use `sync/atomic.Uint32` for lock-free, concurrent-safe reads

## Test plan
- [x] Verify `Status()` returns zero values before compaction starts
- [x] Verify `Total` equals the Commit value from the last input header
- [x] Verify `N` equals the last page written after compaction completes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)