### PR TITLE
refactor(lz4): switch from frame format to block format

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -180,8 +180,8 @@ func (dec *Decoder) DecodePage(hdr *PageHeader, data []byte) error {
 	}
 
 	// Read page data using format-specific approach.
-	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
-		// New block format: read size prefix, then block data.
+	if hdr.Flags&PageHeaderFlagSize != 0 {
+		// New block format: read size prefix, then LZ4 block data.
 		sizeBuf := make([]byte, 4)
 		if _, err := io.ReadFull(dec.r, sizeBuf); err != nil {
 			return fmt.Errorf("read data size: %w", err)
@@ -189,23 +189,12 @@ func (dec *Decoder) DecodePage(hdr *PageHeader, data []byte) error {
 		dec.writeToHash(sizeBuf)
 		dataSize := binary.BigEndian.Uint32(sizeBuf)
 
-		if hdr.Flags&PageHeaderFlagUncompressed != 0 {
-			// Data stored uncompressed - validate size matches page size.
-			if dataSize != dec.header.PageSize {
-				return fmt.Errorf("uncompressed data size mismatch: got %d, expected %d", dataSize, dec.header.PageSize)
-			}
-			if _, err := io.ReadFull(dec.r, data); err != nil {
-				return fmt.Errorf("read uncompressed data: %w", err)
-			}
-		} else {
-			// LZ4 block compressed data.
-			compressed := make([]byte, dataSize)
-			if _, err := io.ReadFull(dec.r, compressed); err != nil {
-				return fmt.Errorf("read compressed data: %w", err)
-			}
-			if _, err := lz4.UncompressBlock(compressed, data); err != nil {
-				return fmt.Errorf("decompress block: %w", err)
-			}
+		compressed := make([]byte, dataSize)
+		if _, err := io.ReadFull(dec.r, compressed); err != nil {
+			return fmt.Errorf("read compressed data: %w", err)
+		}
+		if _, err := lz4.UncompressBlock(compressed, data); err != nil {
+			return fmt.Errorf("decompress block: %w", err)
 		}
 	} else {
 		// Old format: use LimitedReader workaround for lz4 frame concatenation.
@@ -345,7 +334,7 @@ func DecodePageData(b []byte) (hdr PageHeader, data []byte, err error) {
 		return hdr, data, nil
 	}
 
-	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
+	if hdr.Flags&PageHeaderFlagSize != 0 {
 		// New block format: read size and decompress.
 		if len(b) < PageHeaderSize+4 {
 			return hdr, nil, fmt.Errorf("buffer too small for size prefix")
@@ -357,22 +346,16 @@ func DecodePageData(b []byte) (hdr PageHeader, data []byte, err error) {
 			return hdr, nil, fmt.Errorf("buffer too small for data: need %d, have %d", offset+int(dataSize), len(b))
 		}
 
-		if hdr.Flags&PageHeaderFlagUncompressed != 0 {
-			// Data stored uncompressed.
-			data = make([]byte, dataSize)
-			copy(data, b[offset:offset+int(dataSize)])
-		} else {
-			// LZ4 block compressed data.
-			compressed := b[offset : offset+int(dataSize)]
-			// Estimate uncompressed size - pages are typically 512-65536 bytes.
-			// We'll use a reasonable upper bound and resize if needed.
-			data = make([]byte, 65536)
-			n, err := lz4.UncompressBlock(compressed, data)
-			if err != nil {
-				return hdr, nil, fmt.Errorf("decompress block: %w", err)
-			}
-			data = data[:n]
+		// LZ4 block compressed data.
+		compressed := b[offset : offset+int(dataSize)]
+		// Estimate uncompressed size - pages are typically 512-65536 bytes.
+		// We'll use a reasonable upper bound and resize if needed.
+		data = make([]byte, 65536)
+		n, err := lz4.UncompressBlock(compressed, data)
+		if err != nil {
+			return hdr, nil, fmt.Errorf("decompress block: %w", err)
 		}
+		data = data[:n]
 	} else {
 		// Old frame format: use LZ4 reader.
 		r := bytes.NewReader(b[PageHeaderSize:])

--- a/decoder.go
+++ b/decoder.go
@@ -7,14 +7,21 @@ import (
 	"hash"
 	"hash/crc64"
 	"io"
+	"math"
 
 	"github.com/pierrec/lz4/v4"
 )
 
+// lz4FrameFooterSize is the size of the LZ4 frame footer:
+// EndMark (4 bytes) + Content Checksum (4 bytes).
+// Used when decoding old format files without compressed size prefix.
+const lz4FrameFooterSize = 8
+
 // Decoder represents a decoder of an LTX file.
 type Decoder struct {
-	r  io.Reader   // main reader
-	zr *lz4.Reader // lz4 reader
+	r  io.Reader        // main reader
+	lr io.LimitedReader // limited reader for lz4 (reused)
+	zr *lz4.Reader      // lz4 reader
 
 	header    Header
 	trailer   Trailer
@@ -172,18 +179,52 @@ func (dec *Decoder) DecodePage(hdr *PageHeader, data []byte) error {
 		return err
 	}
 
-	// Read page data next.
-	dec.zr.Reset(dec.r)
-	if _, err := io.ReadFull(dec.zr, data); err != nil {
-		return err
+	// Read page data using format-specific approach.
+	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
+		// New format: read compressed size prefix, then use exact LimitedReader.
+		sizeBuf := make([]byte, 4)
+		if _, err := io.ReadFull(dec.r, sizeBuf); err != nil {
+			return fmt.Errorf("read compressed size: %w", err)
+		}
+		dec.writeToHash(sizeBuf)
+
+		compressedSize := binary.BigEndian.Uint32(sizeBuf)
+		dec.lr.R = dec.r
+		dec.lr.N = int64(compressedSize)
+		dec.zr.Reset(&dec.lr)
+
+		if _, err := io.ReadFull(dec.zr, data); err != nil {
+			return err
+		}
+
+		// Drain any remaining bytes from the LimitedReader.
+		// The LZ4 reader may not consume all bytes (e.g., frame trailer).
+		if dec.lr.N > 0 {
+			if _, err := io.CopyN(io.Discard, &dec.lr, dec.lr.N); err != nil {
+				return fmt.Errorf("drain lz4 frame: %w", err)
+			}
+		}
+	} else {
+		// Old format: use LimitedReader workaround for lz4 frame concatenation.
+		// The lz4 library peeks ahead after EOF to check for concatenated frames,
+		// so we limit reads to prevent it from reading into the next page header.
+		dec.lr.R = dec.r
+		dec.lr.N = math.MaxInt64
+		dec.zr.Reset(&dec.lr)
+
+		if _, err := io.ReadFull(dec.zr, data); err != nil {
+			return err
+		}
+
+		// Limit remaining reads to the LZ4 frame footer size before checking EOF.
+		dec.lr.N = lz4FrameFooterSize
+		if err := dec.readLZ4Trailer(); err != nil {
+			return fmt.Errorf("read lz4 trailer: %w", err)
+		}
 	}
+
 	dec.writeToHash(data)
 	dec.pageN++
-
-	// Read off the LZ4 trailer frame to ensure we hit EOF.
-	if err := dec.readLZ4Trailer(); err != nil {
-		return fmt.Errorf("read lz4 trailer: %w", err)
-	}
 
 	// Calculate checksum while decoding snapshots if tracking checksums.
 	if dec.header.IsSnapshot() && !dec.header.NoChecksum() {
@@ -301,7 +342,19 @@ func DecodePageData(b []byte) (hdr PageHeader, data []byte, err error) {
 		return hdr, data, nil
 	}
 
-	zr := lz4.NewReader(bytes.NewReader(b[PageHeaderSize:]))
+	// Determine offset and size of LZ4 data based on format.
+	var r io.Reader
+	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
+		// New format: read compressed size and limit reader to that size.
+		compressedSize := binary.BigEndian.Uint32(b[PageHeaderSize:])
+		offset := PageHeaderSize + 4
+		r = bytes.NewReader(b[offset : offset+int(compressedSize)])
+	} else {
+		// Old format: pass remaining bytes, rely on LZ4 frame boundaries.
+		r = bytes.NewReader(b[PageHeaderSize:])
+	}
+
+	zr := lz4.NewReader(r)
 	data, err = io.ReadAll(zr)
 	return hdr, data, err
 }

--- a/decoder.go
+++ b/decoder.go
@@ -181,27 +181,30 @@ func (dec *Decoder) DecodePage(hdr *PageHeader, data []byte) error {
 
 	// Read page data using format-specific approach.
 	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
-		// New format: read compressed size prefix, then use exact LimitedReader.
+		// New block format: read size prefix, then block data.
 		sizeBuf := make([]byte, 4)
 		if _, err := io.ReadFull(dec.r, sizeBuf); err != nil {
-			return fmt.Errorf("read compressed size: %w", err)
+			return fmt.Errorf("read data size: %w", err)
 		}
 		dec.writeToHash(sizeBuf)
+		dataSize := binary.BigEndian.Uint32(sizeBuf)
 
-		compressedSize := binary.BigEndian.Uint32(sizeBuf)
-		dec.lr.R = dec.r
-		dec.lr.N = int64(compressedSize)
-		dec.zr.Reset(&dec.lr)
-
-		if _, err := io.ReadFull(dec.zr, data); err != nil {
-			return err
-		}
-
-		// Drain any remaining bytes from the LimitedReader.
-		// The LZ4 reader may not consume all bytes (e.g., frame trailer).
-		if dec.lr.N > 0 {
-			if _, err := io.CopyN(io.Discard, &dec.lr, dec.lr.N); err != nil {
-				return fmt.Errorf("drain lz4 frame: %w", err)
+		if hdr.Flags&PageHeaderFlagUncompressed != 0 {
+			// Data stored uncompressed - validate size matches page size.
+			if dataSize != dec.header.PageSize {
+				return fmt.Errorf("uncompressed data size mismatch: got %d, expected %d", dataSize, dec.header.PageSize)
+			}
+			if _, err := io.ReadFull(dec.r, data); err != nil {
+				return fmt.Errorf("read uncompressed data: %w", err)
+			}
+		} else {
+			// LZ4 block compressed data.
+			compressed := make([]byte, dataSize)
+			if _, err := io.ReadFull(dec.r, compressed); err != nil {
+				return fmt.Errorf("read compressed data: %w", err)
+			}
+			if _, err := lz4.UncompressBlock(compressed, data); err != nil {
+				return fmt.Errorf("decompress block: %w", err)
 			}
 		}
 	} else {
@@ -342,20 +345,41 @@ func DecodePageData(b []byte) (hdr PageHeader, data []byte, err error) {
 		return hdr, data, nil
 	}
 
-	// Determine offset and size of LZ4 data based on format.
-	var r io.Reader
 	if hdr.Flags&PageHeaderFlagCompressedSize != 0 {
-		// New format: read compressed size and limit reader to that size.
-		compressedSize := binary.BigEndian.Uint32(b[PageHeaderSize:])
+		// New block format: read size and decompress.
+		if len(b) < PageHeaderSize+4 {
+			return hdr, nil, fmt.Errorf("buffer too small for size prefix")
+		}
+		dataSize := binary.BigEndian.Uint32(b[PageHeaderSize:])
 		offset := PageHeaderSize + 4
-		r = bytes.NewReader(b[offset : offset+int(compressedSize)])
+
+		if len(b) < offset+int(dataSize) {
+			return hdr, nil, fmt.Errorf("buffer too small for data: need %d, have %d", offset+int(dataSize), len(b))
+		}
+
+		if hdr.Flags&PageHeaderFlagUncompressed != 0 {
+			// Data stored uncompressed.
+			data = make([]byte, dataSize)
+			copy(data, b[offset:offset+int(dataSize)])
+		} else {
+			// LZ4 block compressed data.
+			compressed := b[offset : offset+int(dataSize)]
+			// Estimate uncompressed size - pages are typically 512-65536 bytes.
+			// We'll use a reasonable upper bound and resize if needed.
+			data = make([]byte, 65536)
+			n, err := lz4.UncompressBlock(compressed, data)
+			if err != nil {
+				return hdr, nil, fmt.Errorf("decompress block: %w", err)
+			}
+			data = data[:n]
+		}
 	} else {
-		// Old format: pass remaining bytes, rely on LZ4 frame boundaries.
-		r = bytes.NewReader(b[PageHeaderSize:])
+		// Old frame format: use LZ4 reader.
+		r := bytes.NewReader(b[PageHeaderSize:])
+		zr := lz4.NewReader(r)
+		data, err = io.ReadAll(zr)
 	}
 
-	zr := lz4.NewReader(r)
-	data, err = io.ReadAll(zr)
 	return hdr, data, err
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -70,11 +70,11 @@ func TestDecoder(t *testing.T) {
 	}
 
 	// Verify page index.
-	// New format adds 4-byte compressed size prefix, so Size is 55 instead of 51.
+	// Block format: PageHeader(6) + Size(4) + compressed block data (~26 bytes for repetitive data).
 	index := dec.PageIndex()
 	if got, want := index, map[uint32]ltx.PageIndexElem{
-		1: {MinTXID: 1, MaxTXID: 1, Offset: 100, Size: 55},
-		2: {MinTXID: 1, MaxTXID: 1, Offset: 155, Size: 55},
+		1: {MinTXID: 1, MaxTXID: 1, Offset: 100, Size: 36},
+		2: {MinTXID: 1, MaxTXID: 1, Offset: 136, Size: 36},
 	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("page index mismatch:\ngot=%#v\nwant=%#v", got, want)
 	}
@@ -88,8 +88,8 @@ func TestDecoder(t *testing.T) {
 		t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
 	}
 
-	// Read page 2 by offset. Offset is 155 with new format (+4 bytes per page).
-	if hdr, data, err := ltx.DecodePageData(fileSpecData[155:]); err != nil {
+	// Read page 2 by offset. Offset is 136 with block format.
+	if hdr, data, err := ltx.DecodePageData(fileSpecData[136:]); err != nil {
 		t.Fatal(err)
 	} else if got, want := hdr.Pgno, uint32(2); got != want {
 		t.Fatalf("page header pgno mismatch:\ngot=%d\nwant=%d", got, want)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -47,9 +47,15 @@ func TestDecoder(t *testing.T) {
 		data := make([]byte, 1024)
 		if err := dec.DecodePage(&hdr, data); err != nil {
 			t.Fatal(err)
-		} else if got, want := hdr, spec.Pages[i].Header; got != want {
-			t.Fatalf("page hdr mismatch:\ngot=%#v\nwant=%#v", got, want)
-		} else if got, want := data, spec.Pages[i].Data; !bytes.Equal(got, want) {
+		}
+		// Encoder now sets PageHeaderFlagCompressedSize, so compare only Pgno.
+		if got, want := hdr.Pgno, spec.Pages[i].Header.Pgno; got != want {
+			t.Fatalf("page hdr pgno mismatch:\ngot=%d\nwant=%d", got, want)
+		}
+		if got, want := hdr.Flags, uint16(ltx.PageHeaderFlagCompressedSize); got != want {
+			t.Fatalf("page hdr flags mismatch:\ngot=0x%x\nwant=0x%x", got, want)
+		}
+		if got, want := data, spec.Pages[i].Data; !bytes.Equal(got, want) {
 			t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
 		}
 	}
@@ -64,10 +70,11 @@ func TestDecoder(t *testing.T) {
 	}
 
 	// Verify page index.
+	// New format adds 4-byte compressed size prefix, so Size is 55 instead of 51.
 	index := dec.PageIndex()
 	if got, want := index, map[uint32]ltx.PageIndexElem{
-		1: {MinTXID: 1, MaxTXID: 1, Offset: 100, Size: 51},
-		2: {MinTXID: 1, MaxTXID: 1, Offset: 151, Size: 51},
+		1: {MinTXID: 1, MaxTXID: 1, Offset: 100, Size: 55},
+		2: {MinTXID: 1, MaxTXID: 1, Offset: 155, Size: 55},
 	}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("page index mismatch:\ngot=%#v\nwant=%#v", got, want)
 	}
@@ -75,17 +82,17 @@ func TestDecoder(t *testing.T) {
 	// Read page 1 by offset.
 	if hdr, data, err := ltx.DecodePageData(fileSpecData[100:]); err != nil {
 		t.Fatal(err)
-	} else if got, want := hdr, (ltx.PageHeader{Pgno: 1}); got != want {
-		t.Fatalf("page header mismatch:\ngot=%#v\nwant=%#v", got, want)
+	} else if got, want := hdr.Pgno, uint32(1); got != want {
+		t.Fatalf("page header pgno mismatch:\ngot=%d\nwant=%d", got, want)
 	} else if got, want := data, bytes.Repeat([]byte("2"), 1024); !bytes.Equal(got, want) {
 		t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
 	}
 
-	// Read page 2 by offset.
-	if hdr, data, err := ltx.DecodePageData(fileSpecData[151:]); err != nil {
+	// Read page 2 by offset. Offset is 155 with new format (+4 bytes per page).
+	if hdr, data, err := ltx.DecodePageData(fileSpecData[155:]); err != nil {
 		t.Fatal(err)
-	} else if got, want := hdr, (ltx.PageHeader{Pgno: 2}); got != want {
-		t.Fatalf("page header mismatch:\ngot=%#v\nwant=%#v", got, want)
+	} else if got, want := hdr.Pgno, uint32(2); got != want {
+		t.Fatalf("page header pgno mismatch:\ngot=%d\nwant=%d", got, want)
 	} else if got, want := data, bytes.Repeat([]byte("3"), 1024); !bytes.Equal(got, want) {
 		t.Fatalf("page data mismatch:\ngot=%#v\nwant=%#v", got, want)
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -49,11 +49,11 @@ func TestDecoder(t *testing.T) {
 		if err := dec.DecodePage(&hdr, data); err != nil {
 			t.Fatal(err)
 		}
-		// Encoder now sets PageHeaderFlagCompressedSize, so compare only Pgno.
+		// Encoder now sets PageHeaderFlagSize, so compare only Pgno.
 		if got, want := hdr.Pgno, spec.Pages[i].Header.Pgno; got != want {
 			t.Fatalf("page hdr pgno mismatch:\ngot=%d\nwant=%d", got, want)
 		}
-		if got, want := hdr.Flags, uint16(ltx.PageHeaderFlagCompressedSize); got != want {
+		if got, want := hdr.Flags, uint16(ltx.PageHeaderFlagSize); got != want {
 			t.Fatalf("page hdr flags mismatch:\ngot=0x%x\nwant=0x%x", got, want)
 		}
 		if got, want := data, spec.Pages[i].Data; !bytes.Equal(got, want) {
@@ -298,9 +298,8 @@ func TestDecoder_64KBPageSize(t *testing.T) {
 		if !bytes.Equal(data, page1Data) {
 			t.Fatal("page 1 data mismatch")
 		}
-		// Should be compressed (flag without uncompressed bit).
-		if hdr.Flags != ltx.PageHeaderFlagCompressedSize {
-			t.Fatalf("expected compressed flag only, got 0x%x", hdr.Flags)
+		if hdr.Flags != ltx.PageHeaderFlagSize {
+			t.Fatalf("expected size flag, got 0x%x", hdr.Flags)
 		}
 
 		if err := dec.DecodePage(&hdr, data); err != nil {
@@ -372,10 +371,9 @@ func TestDecoder_64KBPageSize(t *testing.T) {
 		if !bytes.Equal(data, page1Data) {
 			t.Fatal("page 1 data mismatch")
 		}
-		// Should be stored uncompressed (random data doesn't compress).
-		expectedFlags := ltx.PageHeaderFlagCompressedSize | ltx.PageHeaderFlagUncompressed
-		if hdr.Flags != expectedFlags {
-			t.Fatalf("expected uncompressed flags 0x%x, got 0x%x", expectedFlags, hdr.Flags)
+		// Random data is still compressed (even if slightly larger).
+		if hdr.Flags != ltx.PageHeaderFlagSize {
+			t.Fatalf("expected size flag 0x%x, got 0x%x", ltx.PageHeaderFlagSize, hdr.Flags)
 		}
 
 		if err := dec.DecodePage(&hdr, data); err != io.EOF {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2,6 +2,7 @@ package ltx_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io"
 	"reflect"
 	"testing"
@@ -235,6 +236,152 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 		writeFileSpec(t, &buf, spec)
 		dec := ltx.NewDecoder(&buf)
 		if err := dec.DecodeDatabaseTo(io.Discard); err == nil || err.Error() != `cannot decode non-snapshot LTX file to SQLite database` {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDecoder_64KBPageSize(t *testing.T) {
+	const pageSize = 65536 // 64KB - maximum SQLite page size
+
+	t.Run("Compressible", func(t *testing.T) {
+		// Test with compressible data (repetitive pattern).
+		page1Data := bytes.Repeat([]byte("A"), pageSize)
+		page2Data := bytes.Repeat([]byte("B"), pageSize)
+
+		// Calculate correct post-apply checksum.
+		chksum := ltx.ChecksumFlag
+		chksum = ltx.ChecksumFlag | (chksum ^ ltx.ChecksumPage(1, page1Data))
+		chksum = ltx.ChecksumFlag | (chksum ^ ltx.ChecksumPage(2, page2Data))
+
+		var buf bytes.Buffer
+		enc, err := ltx.NewEncoder(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{
+			Version:   ltx.Version,
+			PageSize:  pageSize,
+			Commit:    2,
+			MinTXID:   1,
+			MaxTXID:   1,
+			Timestamp: 1000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1Data); err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: 2}, page2Data); err != nil {
+			t.Fatal(err)
+		}
+		enc.SetPostApplyChecksum(chksum)
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Decode and verify.
+		dec := ltx.NewDecoder(&buf)
+		if err := dec.DecodeHeader(); err != nil {
+			t.Fatal(err)
+		}
+
+		var hdr ltx.PageHeader
+		data := make([]byte, pageSize)
+
+		if err := dec.DecodePage(&hdr, data); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Pgno != 1 {
+			t.Fatalf("expected pgno 1, got %d", hdr.Pgno)
+		}
+		if !bytes.Equal(data, page1Data) {
+			t.Fatal("page 1 data mismatch")
+		}
+		// Should be compressed (flag without uncompressed bit).
+		if hdr.Flags != ltx.PageHeaderFlagCompressedSize {
+			t.Fatalf("expected compressed flag only, got 0x%x", hdr.Flags)
+		}
+
+		if err := dec.DecodePage(&hdr, data); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Pgno != 2 {
+			t.Fatalf("expected pgno 2, got %d", hdr.Pgno)
+		}
+		if !bytes.Equal(data, page2Data) {
+			t.Fatal("page 2 data mismatch")
+		}
+
+		if err := dec.DecodePage(&hdr, data); err != io.EOF {
+			t.Fatalf("expected EOF, got %v", err)
+		}
+		if err := dec.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("Incompressible", func(t *testing.T) {
+		// Test with incompressible data (truly random bytes).
+		page1Data := make([]byte, pageSize)
+		if _, err := rand.Read(page1Data); err != nil {
+			t.Fatal(err)
+		}
+
+		// Calculate correct post-apply checksum.
+		chksum := ltx.ChecksumFlag | ltx.ChecksumPage(1, page1Data)
+
+		var buf bytes.Buffer
+		enc, err := ltx.NewEncoder(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{
+			Version:   ltx.Version,
+			PageSize:  pageSize,
+			Commit:    1,
+			MinTXID:   1,
+			MaxTXID:   1,
+			Timestamp: 1000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: 1}, page1Data); err != nil {
+			t.Fatal(err)
+		}
+		enc.SetPostApplyChecksum(chksum)
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Decode and verify.
+		dec := ltx.NewDecoder(&buf)
+		if err := dec.DecodeHeader(); err != nil {
+			t.Fatal(err)
+		}
+
+		var hdr ltx.PageHeader
+		data := make([]byte, pageSize)
+
+		if err := dec.DecodePage(&hdr, data); err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Pgno != 1 {
+			t.Fatalf("expected pgno 1, got %d", hdr.Pgno)
+		}
+		if !bytes.Equal(data, page1Data) {
+			t.Fatal("page 1 data mismatch")
+		}
+		// Should be stored uncompressed (random data doesn't compress).
+		expectedFlags := ltx.PageHeaderFlagCompressedSize | ltx.PageHeaderFlagUncompressed
+		if hdr.Flags != expectedFlags {
+			t.Fatalf("expected uncompressed flags 0x%x, got 0x%x", expectedFlags, hdr.Flags)
+		}
+
+		if err := dec.DecodePage(&hdr, data); err != io.EOF {
+			t.Fatalf("expected EOF, got %v", err)
+		}
+		if err := dec.Close(); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/encoder.go
+++ b/encoder.go
@@ -243,18 +243,41 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 
 	offset := enc.n
 
-	// Encode & write header.
+	// Compress data first to get the compressed size.
+	enc.buf.Reset()
+	enc.zw.Reset(&enc.buf)
+	if _, err = enc.zw.Write(data); err != nil {
+		return fmt.Errorf("compress page data: %w", err)
+	}
+	if err := enc.zw.Close(); err != nil {
+		return fmt.Errorf("close lz4 writer: %w", err)
+	}
+	compressed := enc.buf.Bytes()
+
+	// Set flag indicating compressed size follows the page header.
+	hdr.Flags |= PageHeaderFlagCompressedSize
+
+	// Write page header.
 	b, err := hdr.MarshalBinary()
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
 	} else if _, err := enc.write(b); err != nil {
-		return fmt.Errorf("write: %w", err)
+		return fmt.Errorf("write page header: %w", err)
 	}
 
-	// Write data to file.
-	if _, err = enc.writeCompressed(data); err != nil {
-		return fmt.Errorf("write page data: %w", err)
+	// Write compressed size (4 bytes, big-endian).
+	sizeBuf := make([]byte, 4)
+	binary.BigEndian.PutUint32(sizeBuf, uint32(len(compressed)))
+	if _, err := enc.write(sizeBuf); err != nil {
+		return fmt.Errorf("write compressed size: %w", err)
 	}
+
+	// Write compressed data.
+	if _, err := enc.w.Write(compressed); err != nil {
+		return fmt.Errorf("write compressed data: %w", err)
+	}
+	_, _ = enc.hash.Write(data) // hash the uncompressed data
+	enc.n += int64(len(compressed))
 
 	enc.pagesWritten++
 	enc.prevPgno = hdr.Pgno
@@ -270,34 +293,6 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 func (enc *Encoder) write(b []byte) (n int, err error) {
 	n, err = enc.w.Write(b)
 	enc.writeToHash(b[:n])
-	return n, err
-}
-
-// write to the compressed writer & add to the checksum.
-// Returns the size of the compressed data.
-func (enc *Encoder) writeCompressed(b []byte) (n int, err error) {
-	// Reset the buffer & compressed writer.
-	enc.buf.Reset()
-	enc.zw.Reset(&enc.buf)
-
-	// Write to the compressed writer to the buffer and then write the buffer to the uncompressed writer.
-	// This is necessary so we can calculate the size of the compressed data for the page index.
-	if _, err = enc.zw.Write(b); err != nil {
-		return n, err
-	}
-
-	// Close the compressed writer to flush any remaining data.
-	if err := enc.zw.Close(); err != nil {
-		return n, fmt.Errorf("cannot close lz4 writer: %w", err)
-	}
-
-	compressed := enc.buf.Bytes()
-	n, err = enc.w.Write(compressed)
-
-	// Write the uncompressed data to the hash, but add the compressed length to the size.
-	_, _ = enc.hash.Write(b)
-	enc.n += int64(len(compressed))
-
 	return n, err
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -236,19 +236,14 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 	if err != nil {
 		return fmt.Errorf("compress page data: %w", err)
 	}
-
-	// Set flag indicating compressed size follows the page header (block format).
-	hdr.Flags |= PageHeaderFlagCompressedSize
-
-	// Determine what data to write based on compression result.
-	var writeData []byte
-	if n == 0 || n >= len(data) {
-		// Incompressible or compression didn't help - store uncompressed.
-		hdr.Flags |= PageHeaderFlagUncompressed
-		writeData = data
-	} else {
-		writeData = enc.compressBuf[:n]
+	if n == 0 {
+		return fmt.Errorf("lz4 block compression failed")
 	}
+
+	// Set flag indicating size field follows the page header (block format).
+	hdr.Flags |= PageHeaderFlagSize
+
+	writeData := enc.compressBuf[:n]
 
 	// Write page header.
 	b, err := hdr.MarshalBinary()

--- a/encoder.go
+++ b/encoder.go
@@ -1,7 +1,6 @@
 package ltx
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -14,16 +13,18 @@ import (
 
 // Encoder implements an encoder for an LTX file.
 type Encoder struct {
-	w     io.Writer   // main writer
-	zw    *lz4.Writer // compressed writer
+	w     io.Writer // main writer
 	state string
 
 	header  Header
 	trailer Trailer
-	buf     bytes.Buffer
 	hash    hash.Hash64
 	index   map[uint32]PageIndexElem // page number to offset
 	n       int64                    // bytes written
+
+	// LZ4 block compression
+	compressor  lz4.Compressor
+	compressBuf []byte
 
 	// Track how many of each write has occurred to move state.
 	prevPgno     uint32
@@ -32,24 +33,11 @@ type Encoder struct {
 
 // NewEncoder returns a new instance of Encoder.
 func NewEncoder(w io.Writer) (*Encoder, error) {
-	enc := &Encoder{
+	return &Encoder{
 		w:     w,
 		state: stateHeader,
 		index: make(map[uint32]PageIndexElem),
-	}
-
-	// The compressed writer writes to a buffer so we can calculate the size
-	// of the compressed data for the page index.
-	zw := lz4.NewWriter(&enc.buf)
-	if err := zw.Apply(lz4.BlockSizeOption(lz4.Block64Kb)); err != nil { // minimize memory allocation
-		return nil, fmt.Errorf("cannot set lz4 block size: %w", err)
-	}
-	if err := zw.Apply(lz4.CompressionLevelOption(lz4.Fast)); err != nil {
-		return nil, fmt.Errorf("cannot set lz4 compression level: %w", err)
-	}
-	enc.zw = zw
-
-	return enc, nil
+	}, nil
 }
 
 // N returns the number of bytes written.
@@ -90,11 +78,6 @@ func (enc *Encoder) Close() error {
 		return fmt.Errorf("marshal empty page header: %w", err)
 	} else if _, err := enc.write(b0); err != nil {
 		return fmt.Errorf("write empty page header: %w", err)
-	}
-
-	// Close the compressed writer.
-	if err := enc.zw.Close(); err != nil {
-		return fmt.Errorf("cannot close lz4 writer: %w", err)
 	}
 
 	// Write index to file.
@@ -243,19 +226,29 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 
 	offset := enc.n
 
-	// Compress data first to get the compressed size.
-	enc.buf.Reset()
-	enc.zw.Reset(&enc.buf)
-	if _, err = enc.zw.Write(data); err != nil {
+	// Allocate compression buffer if needed.
+	if enc.compressBuf == nil {
+		enc.compressBuf = make([]byte, lz4.CompressBlockBound(int(enc.header.PageSize)))
+	}
+
+	// Compress data using LZ4 block compression.
+	n, err := enc.compressor.CompressBlock(data, enc.compressBuf)
+	if err != nil {
 		return fmt.Errorf("compress page data: %w", err)
 	}
-	if err := enc.zw.Close(); err != nil {
-		return fmt.Errorf("close lz4 writer: %w", err)
-	}
-	compressed := enc.buf.Bytes()
 
-	// Set flag indicating compressed size follows the page header.
+	// Set flag indicating compressed size follows the page header (block format).
 	hdr.Flags |= PageHeaderFlagCompressedSize
+
+	// Determine what data to write based on compression result.
+	var writeData []byte
+	if n == 0 || n >= len(data) {
+		// Incompressible or compression didn't help - store uncompressed.
+		hdr.Flags |= PageHeaderFlagUncompressed
+		writeData = data
+	} else {
+		writeData = enc.compressBuf[:n]
+	}
 
 	// Write page header.
 	b, err := hdr.MarshalBinary()
@@ -265,19 +258,19 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 		return fmt.Errorf("write page header: %w", err)
 	}
 
-	// Write compressed size (4 bytes, big-endian).
+	// Write data size (4 bytes, big-endian).
 	sizeBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(sizeBuf, uint32(len(compressed)))
+	binary.BigEndian.PutUint32(sizeBuf, uint32(len(writeData)))
 	if _, err := enc.write(sizeBuf); err != nil {
-		return fmt.Errorf("write compressed size: %w", err)
+		return fmt.Errorf("write data size: %w", err)
 	}
 
-	// Write compressed data.
-	if _, err := enc.w.Write(compressed); err != nil {
-		return fmt.Errorf("write compressed data: %w", err)
+	// Write page data (compressed or uncompressed).
+	if _, err := enc.w.Write(writeData); err != nil {
+		return fmt.Errorf("write page data: %w", err)
 	}
 	_, _ = enc.hash.Write(data) // hash the uncompressed data
-	enc.n += int64(len(compressed))
+	enc.n += int64(len(writeData))
 
 	enc.pagesWritten++
 	enc.prevPgno = hdr.Pgno

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/superfly/ltx
 
 go 1.24
 
-require github.com/pierrec/lz4/v4 v4.1.22
+require github.com/pierrec/lz4/v4 v4.1.23

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
-github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.23 h1:oJE7T90aYBGtFNrI8+KbETnPymobAhzRrR8Mu8n1yfU=
+github.com/pierrec/lz4/v4 v4.1.23/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=

--- a/ltx.go
+++ b/ltx.go
@@ -408,10 +408,16 @@ func IsValidPageSize(sz uint32) bool {
 // PageHeader flags.
 const (
 	// PageHeaderFlagCompressedSize indicates that a 4-byte compressed size
-	// field follows the page header. This allows the decoder to know the exact
-	// size of the LZ4 frame without relying on the LZ4 library's frame
-	// concatenation behavior.
+	// field follows the page header. When set, data uses LZ4 block format
+	// (not frame format).
 	PageHeaderFlagCompressedSize = uint16(1 << 0)
+
+	// PageHeaderFlagUncompressed indicates the page data is stored without
+	// compression. Used when LZ4 compression would not reduce size.
+	PageHeaderFlagUncompressed = uint16(1 << 1)
+
+	// pageHeaderFlagMask is the mask of valid page header flags.
+	pageHeaderFlagMask = PageHeaderFlagCompressedSize | PageHeaderFlagUncompressed
 )
 
 // PageHeader represents the header for a single page in an LTX file.
@@ -430,7 +436,7 @@ func (h *PageHeader) Validate() error {
 	if h.Pgno == 0 {
 		return fmt.Errorf("page number required")
 	}
-	if h.Flags & ^PageHeaderFlagCompressedSize != 0 {
+	if h.Flags & ^pageHeaderFlagMask != 0 {
 		return fmt.Errorf("invalid page header flags: 0x%04x", h.Flags)
 	}
 	return nil

--- a/ltx.go
+++ b/ltx.go
@@ -405,6 +405,15 @@ func IsValidPageSize(sz uint32) bool {
 	return false
 }
 
+// PageHeader flags.
+const (
+	// PageHeaderFlagCompressedSize indicates that a 4-byte compressed size
+	// field follows the page header. This allows the decoder to know the exact
+	// size of the LZ4 frame without relying on the LZ4 library's frame
+	// concatenation behavior.
+	PageHeaderFlagCompressedSize = uint16(1 << 0)
+)
+
 // PageHeader represents the header for a single page in an LTX file.
 type PageHeader struct {
 	Pgno  uint32
@@ -421,8 +430,8 @@ func (h *PageHeader) Validate() error {
 	if h.Pgno == 0 {
 		return fmt.Errorf("page number required")
 	}
-	if h.Flags != 0 {
-		return fmt.Errorf("no flags allowed, reserved for future use")
+	if h.Flags & ^PageHeaderFlagCompressedSize != 0 {
+		return fmt.Errorf("invalid page header flags: 0x%04x", h.Flags)
 	}
 	return nil
 }

--- a/ltx.go
+++ b/ltx.go
@@ -407,17 +407,9 @@ func IsValidPageSize(sz uint32) bool {
 
 // PageHeader flags.
 const (
-	// PageHeaderFlagCompressedSize indicates that a 4-byte compressed size
-	// field follows the page header. When set, data uses LZ4 block format
-	// (not frame format).
-	PageHeaderFlagCompressedSize = uint16(1 << 0)
-
-	// PageHeaderFlagUncompressed indicates the page data is stored without
-	// compression. Used when LZ4 compression would not reduce size.
-	PageHeaderFlagUncompressed = uint16(1 << 1)
-
-	// pageHeaderFlagMask is the mask of valid page header flags.
-	pageHeaderFlagMask = PageHeaderFlagCompressedSize | PageHeaderFlagUncompressed
+	// PageHeaderFlagSize indicates that a 4-byte size field follows the page
+	// header. When set, data uses LZ4 block format (not frame format).
+	PageHeaderFlagSize = uint16(1 << 0)
 )
 
 // PageHeader represents the header for a single page in an LTX file.
@@ -436,7 +428,7 @@ func (h *PageHeader) Validate() error {
 	if h.Pgno == 0 {
 		return fmt.Errorf("page number required")
 	}
-	if h.Flags & ^pageHeaderFlagMask != 0 {
+	if h.Flags & ^PageHeaderFlagSize != 0 {
 		return fmt.Errorf("invalid page header flags: 0x%04x", h.Flags)
 	}
 	return nil

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -816,7 +816,7 @@ func assertFileSpecEqual(tb testing.TB, x, y *ltx.FileSpec) {
 		tb.Fatalf("page count: %d, want %d", got, want)
 	}
 	for i := range x.Pages {
-		// Compare only Pgno, not Flags. The encoder sets PageHeaderFlagCompressedSize
+		// Compare only Pgno, not Flags. The encoder sets PageHeaderFlagSize
 		// on output, so Flags won't match the input spec.
 		if got, want := x.Pages[i].Header.Pgno, y.Pages[i].Header.Pgno; got != want {
 			tb.Fatalf("page header pgno mismatch: i=%d\ngot=%d\nwant=%d", i, got, want)

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -274,8 +274,8 @@ func TestPageHeader_Validate(t *testing.T) {
 		}
 	})
 	t.Run("ErrFlagsNotAllowed", func(t *testing.T) {
-		hdr := ltx.PageHeader{Pgno: 1, Flags: 2}
-		if err := hdr.Validate(); err == nil || err.Error() != `invalid page header flags: 0x0002` {
+		hdr := ltx.PageHeader{Pgno: 1, Flags: 4}
+		if err := hdr.Validate(); err == nil || err.Error() != `invalid page header flags: 0x0004` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -275,7 +275,7 @@ func TestPageHeader_Validate(t *testing.T) {
 	})
 	t.Run("ErrFlagsNotAllowed", func(t *testing.T) {
 		hdr := ltx.PageHeader{Pgno: 1, Flags: 2}
-		if err := hdr.Validate(); err == nil || err.Error() != `no flags allowed, reserved for future use` {
+		if err := hdr.Validate(); err == nil || err.Error() != `invalid page header flags: 0x0002` {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
@@ -816,15 +816,19 @@ func assertFileSpecEqual(tb testing.TB, x, y *ltx.FileSpec) {
 		tb.Fatalf("page count: %d, want %d", got, want)
 	}
 	for i := range x.Pages {
-		if got, want := x.Pages[i].Header, y.Pages[i].Header; got != want {
-			tb.Fatalf("page header mismatch: i=%d\ngot=%#v\nwant=%#v", i, got, want)
+		// Compare only Pgno, not Flags. The encoder sets PageHeaderFlagCompressedSize
+		// on output, so Flags won't match the input spec.
+		if got, want := x.Pages[i].Header.Pgno, y.Pages[i].Header.Pgno; got != want {
+			tb.Fatalf("page header pgno mismatch: i=%d\ngot=%d\nwant=%d", i, got, want)
 		}
 		if got, want := x.Pages[i].Data, y.Pages[i].Data; !bytes.Equal(got, want) {
 			tb.Fatalf("page data mismatch: i=%d\ngot=%#v\nwant=%#v", i, got, want)
 		}
 	}
 
-	if got, want := x.Trailer, y.Trailer; got != want {
-		tb.Fatalf("trailer mismatch:\ngot=%#v\nwant=%#v", got, want)
+	// Compare only PostApplyChecksum, not FileChecksum. FileChecksum depends on
+	// the exact byte representation of the file, which changes when the format changes.
+	if got, want := x.Trailer.PostApplyChecksum, y.Trailer.PostApplyChecksum; got != want {
+		tb.Fatalf("trailer PostApplyChecksum mismatch:\ngot=0x%x\nwant=0x%x", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Switch from LZ4 frame format to block format, eliminating ~15-23 bytes overhead per page
- Rename `PageHeaderFlagCompressedSize` to `PageHeaderFlagSize` (applies to all block format data)
- Always compress data (removed uncompressed path per review feedback)
- Maintain backward compatibility with old frame format files

This addresses feedback from @ncruces and @benbjohnson on PR #72:
> "I don't think a checksum buys us much. Are we able to drop the LZ4 frame?"

## Changes

| File | Description |
|------|-------------|
| `ltx.go` | Add `PageHeaderFlagSize` constant (renamed from `PageHeaderFlagCompressedSize`) |
| `encoder.go` | Use `lz4.Compressor.CompressBlock()` instead of frame writer |
| `decoder.go` | Use `lz4.UncompressBlock()` for new format, keep frame fallback |
| `*_test.go` | Update expected page sizes and flag references |

## Format Comparison

```
Old (frame):  [PageHeader:6][LZ4 Frame with ~15-27 byte overhead]
PR #72:       [PageHeader:6][Size:4][LZ4 Frame]
New (block):  [PageHeader:6][Size:4][LZ4 Block Data]
```

## Backward Compatibility

| Format | Flags | Handling |
|--------|-------|----------|
| Old frame (no flag) | 0x0000 | LimitedReader + frame reader |
| New block format | 0x0001 | Read size, UncompressBlock |

## Review Feedback Addressed

- ✅ Renamed `PageHeaderFlagCompressedSize` → `PageHeaderFlagSize` (per @benbjohnson)
- ✅ Removed uncompressed storage path - always compress (per @benbjohnson and @ncruces)
  - Max LZ4 block overhead is only 0.8% for 4K pages

## Test plan

- [x] All existing tests pass
- [x] Decoder handles both old frame format and new block format
- [x] 64KB page size tests for both compressible and incompressible data

🤖 Generated with [Claude Code](https://claude.ai/code)