### PR TITLE
fix(compactor): return header decode errors

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -75,15 +75,15 @@ func (c *Compactor) Status() CompactorStatus {
 }
 
 // Compact merges the input readers into a single LTX writer.
-func (c *Compactor) Compact(ctx context.Context) (retErr error) {
+func (c *Compactor) Compact(ctx context.Context) error {
 	if len(c.inputs) == 0 {
 		return fmt.Errorf("at least one input reader required")
 	}
 
 	// Read headers from all inputs.
-	for _, input := range c.inputs {
+	for i, input := range c.inputs {
 		if err := input.dec.DecodeHeader(); err != nil {
-			return
+			return fmt.Errorf("decode header for input %d: %w", i, err)
 		}
 	}
 

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -3,6 +3,7 @@ package ltx_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -251,6 +252,20 @@ func TestCompactor_Compact(t *testing.T) {
 		}
 		if err := c.Compact(context.Background()); err == nil || err.Error() != `at least one input reader required` {
 			t.Fatalf("unexpected error: %s", err)
+		}
+	})
+	t.Run("ErrDecodeHeader", func(t *testing.T) {
+		c, err := ltx.NewCompactor(io.Discard, []io.Reader{bytes.NewReader(nil)})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = c.Compact(context.Background())
+		if err == nil || err.Error() != `decode header for input 0: EOF` {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("expected EOF, got: %v", err)
 		}
 	})
 	t.Run("ErrPageSizeMismatch", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Return input header decoding failures instead of reporting successful compaction
- Include the failing input index while preserving the original error for inspection
- Remove the unused named error result and cover the regression

Fixes #79

## Test Plan

- `go build ./...`
- `go test ./... -count=1`
- `golangci-lint run --new-from-rev origin/main`
- Changed-file coverage: 88.6%
- `govulncheck ./...`
