### PR TITLE
fix(checksum): exclude lock page and close files

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -86,12 +86,17 @@ func checksumPagesSerial(dbPath string, firstPage, lastPage uint32, pageSize int
 
 	buf := make([]byte, pageSize+4)
 	h := NewHasher()
+	lockPgno := LockPgno(uint32(pageSize))
 
 	for pageNo := firstPage; pageNo <= lastPage; pageNo++ {
 		binary.BigEndian.PutUint32(buf, pageNo)
 
 		if _, err := io.ReadFull(f, buf[4:]); err != nil {
 			return pageNo - 1, err
+		}
+		if pageNo == lockPgno {
+			checksums[pageNo-1] = 0
+			continue
 		}
 
 		h.Reset()
@@ -118,6 +123,7 @@ func ChecksumPageWithHasher(h hash.Hash64, pgno uint32, data []byte) Checksum {
 // ChecksumReader reads an entire database file from r and computes its rolling checksum.
 func ChecksumReader(r io.Reader, pageSize int) (Checksum, error) {
 	data := make([]byte, pageSize)
+	lockPgno := LockPgno(uint32(pageSize))
 
 	var chksum Checksum
 	for pgno := uint32(1); ; pgno++ {
@@ -126,7 +132,9 @@ func ChecksumReader(r io.Reader, pageSize int) (Checksum, error) {
 		} else if err != nil {
 			return chksum, err
 		}
-		chksum = ChecksumFlag | (chksum ^ ChecksumPage(pgno, data))
+		if pgno != lockPgno {
+			chksum = ChecksumFlag | (chksum ^ ChecksumPage(pgno, data))
+		}
 	}
 	return chksum, nil
 }

--- a/checksum.go
+++ b/checksum.go
@@ -78,6 +78,7 @@ func checksumPagesSerial(dbPath string, firstPage, lastPage uint32, pageSize int
 	if err != nil {
 		return firstPage - 1, err
 	}
+	defer func() { _ = f.Close() }()
 
 	_, err = f.Seek(int64(firstPage-1)*pageSize, io.SeekStart)
 	if err != nil {

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -29,6 +29,50 @@ func TestChecksumPages(t *testing.T) {
 	testChecksumPages(t, 0, 4, 1024, 4)
 }
 
+func TestChecksumPages_LockPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	const pageSize = uint32(4096)
+	lockPgno := LockPgno(pageSize)
+	nPages := lockPgno + 100
+	path := filepath.Join(t.TempDir(), "test.db")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := f.Truncate(int64(nPages) * int64(pageSize)); err != nil {
+		t.Fatal(err)
+	}
+
+	checksums := make([]Checksum, nPages)
+	checksums[lockPgno-1] = ChecksumFlag | 1
+	lastPage, err := ChecksumPages(path, pageSize, nPages, 0, checksums)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := lastPage, nPages; got != want {
+		t.Fatalf("last page=%d, want %d", got, want)
+	}
+	if got := checksums[lockPgno-1]; got != 0 {
+		t.Fatalf("lock page checksum=%s, want 0", got)
+	}
+
+	zeroPage := make([]byte, pageSize)
+	for _, pgno := range []uint32{lockPgno - 1, lockPgno + 1} {
+		if got, want := checksums[pgno-1], ChecksumPage(pgno, zeroPage); got != want {
+			t.Fatalf("page %d checksum=%s, want %s", pgno, got, want)
+		}
+	}
+}
+
 func testChecksumPages(t *testing.T, fileSize, nPages, pageSize, nWorkers uint32) {
 	t.Run(fmt.Sprintf("fileSize=%d,nPages=%d,pageSize=%d,nWorkers=%d", fileSize, nPages, pageSize, nWorkers), func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "test.db")

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -180,6 +180,9 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 			t.Skip("skipping in short mode")
 		}
 
+		// This is the canonical lock-page-excluded checksum for the fixture.
+		const canonicalPostApplyChecksum = ltx.Checksum(0xc19b668c376662c7)
+
 		lockPgno := ltx.LockPgno(4096)
 		commit := lockPgno + 10
 
@@ -209,6 +212,9 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 		postApplyChecksum, err := ltx.ChecksumReader(bytes.NewReader(want.Bytes()), 4096)
 		if err != nil {
 			t.Fatal(err)
+		}
+		if got, want := postApplyChecksum, canonicalPostApplyChecksum; got != want {
+			t.Fatalf("post-apply checksum=%s, want canonical lock-page-excluded checksum %s", got, want)
 		}
 		enc.SetPostApplyChecksum(postApplyChecksum)
 		if err := enc.Close(); err != nil {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -206,7 +206,11 @@ func TestDecoder_DecodeDatabaseTo(t *testing.T) {
 			}
 		}
 
-		enc.SetPostApplyChecksum(0xc19b668c376662c7)
+		postApplyChecksum, err := ltx.ChecksumReader(bytes.NewReader(want.Bytes()), 4096)
+		if err != nil {
+			t.Fatal(err)
+		}
+		enc.SetPostApplyChecksum(postApplyChecksum)
 		if err := enc.Close(); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Summary

- omit SQLite's lock page from `ChecksumReader` rolling checksums
- write a literal zero to the lock-page slot in `ChecksumPages`
- close every database file opened by `checksumPagesSerial`
- cover the greater-than-1-GiB boundary with sparse-file and decoder regressions

## Root cause

The decoder, encoder, and database encoder already treat SQLite's lock page as outside the logical database checksum. `ChecksumReader` still folded that page into its rolling XOR, while `ChecksumPages` returned a normal per-page checksum for it. Snapshot verification therefore disagreed above the pending-byte boundary. Separately, each checksum worker left its database file descriptor open.

## Impact

Checksum-tracked snapshots of databases larger than 1 GiB now use the same lock-page exclusion across all code paths. Repeated parallel page scans no longer leak file descriptors.

## Validation

- `go test -v ./...`
- `go install ./cmd/ltx`

This is intentionally a draft because the exported `ChecksumPages` per-page contract needs Fly/LiteFS team sign-off before merge.

Fixes #84
Fixes #85