### PR TITLE
fix(encode-db): write valid snapshots safely

### DIFF
--- a/cmd/ltx/encode_db.go
+++ b/cmd/ltx/encode_db.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/superfly/ltx"
@@ -59,26 +61,49 @@ Arguments:
 	}
 	defer func() { _ = db.Close() }()
 
-	out, err := os.OpenFile(*outPath, os.O_CREATE|os.O_WRONLY, 0o644)
+	dbInfo, err := db.Stat()
 	if err != nil {
-		return fmt.Errorf("open output file: %w", err)
+		return fmt.Errorf("stat DB file: %w", err)
 	}
-	defer func() { _ = out.Close() }()
+	outMode := os.FileMode(0o644)
+	if outInfo, err := os.Stat(*outPath); err == nil {
+		if os.SameFile(dbInfo, outInfo) {
+			return fmt.Errorf("input and output files are the same")
+		}
+		outMode = outInfo.Mode().Perm()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat output file: %w", err)
+	}
 
 	rd, hdr, err := c.readSQLiteDatabaseHeader(db)
 	if err != nil {
 		return fmt.Errorf("read database header: %w", err)
 	}
 
-	var flags uint32
+	out, err := os.CreateTemp(filepath.Dir(*outPath), "."+filepath.Base(*outPath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary output file: %w", err)
+	}
+	tmpPath := out.Name()
+	defer func() {
+		if out != nil {
+			_ = out.Close()
+		}
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := out.Chmod(outMode); err != nil {
+		return fmt.Errorf("chmod temporary output file: %w", err)
+	}
+
 	var postApplyChecksum ltx.Checksum
 	enc, err := ltx.NewEncoder(out)
 	if err != nil {
 		return fmt.Errorf("create ltx encoder: %w", err)
 	}
 	if err := enc.EncodeHeader(ltx.Header{
-		Version:   1,
-		Flags:     flags,
+		Version:   ltx.Version,
 		PageSize:  hdr.pageSize,
 		Commit:    hdr.pageN,
 		MinTXID:   ltx.TXID(1),
@@ -113,6 +138,11 @@ Arguments:
 	} else if err := out.Close(); err != nil {
 		return fmt.Errorf("close ltx file: %w", err)
 	}
+	out = nil
+	if err := os.Rename(tmpPath, *outPath); err != nil {
+		return fmt.Errorf("rename temporary output file: %w", err)
+	}
+	tmpPath = ""
 
 	return nil
 }

--- a/cmd/ltx/encode_db.go
+++ b/cmd/ltx/encode_db.go
@@ -65,12 +65,14 @@ Arguments:
 	if err != nil {
 		return fmt.Errorf("stat DB file: %w", err)
 	}
-	outMode := os.FileMode(0o644)
+	var outMode os.FileMode
+	var preserveOutMode bool
 	if outInfo, err := os.Stat(*outPath); err == nil {
 		if os.SameFile(dbInfo, outInfo) {
 			return fmt.Errorf("input and output files are the same")
 		}
 		outMode = outInfo.Mode().Perm()
+		preserveOutMode = true
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("stat output file: %w", err)
 	}
@@ -93,8 +95,10 @@ Arguments:
 			_ = os.Remove(tmpPath)
 		}
 	}()
-	if err := out.Chmod(outMode); err != nil {
-		return fmt.Errorf("chmod temporary output file: %w", err)
+	if preserveOutMode {
+		if err := out.Chmod(outMode); err != nil {
+			return fmt.Errorf("chmod temporary output file: %w", err)
+		}
 	}
 
 	var postApplyChecksum ltx.Checksum

--- a/cmd/ltx/encode_db_test.go
+++ b/cmd/ltx/encode_db_test.go
@@ -47,6 +47,46 @@ func TestEncodeDBCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("NewOutputMode", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db")
+		writeSQLiteDatabase(t, dbPath)
+
+		outPath := filepath.Join(dir, "ltx")
+		if err := NewEncodeDBCommand().Run(context.Background(), []string{"-o", outPath, dbPath}); err != nil {
+			t.Fatal(err)
+		}
+
+		if info, err := os.Stat(outPath); err != nil {
+			t.Fatal(err)
+		} else if got := info.Mode().Perm(); got&0o077 != 0 {
+			t.Fatalf("mode=%#o, want no group or world permissions", got)
+		}
+	})
+
+	t.Run("ExistingOutputMode", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db")
+		writeSQLiteDatabase(t, dbPath)
+
+		outPath := filepath.Join(dir, "ltx")
+		if err := os.WriteFile(outPath, nil, 0o600); err != nil {
+			t.Fatal(err)
+		} else if err := os.Chmod(outPath, 0o640); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := NewEncodeDBCommand().Run(context.Background(), []string{"-o", outPath, dbPath}); err != nil {
+			t.Fatal(err)
+		}
+
+		if info, err := os.Stat(outPath); err != nil {
+			t.Fatal(err)
+		} else if got, want := info.Mode().Perm(), os.FileMode(0o640); got != want {
+			t.Fatalf("mode=%#o, want %#o", got, want)
+		}
+	})
+
 	t.Run("ErrSameFile", func(t *testing.T) {
 		for _, tt := range []struct {
 			name  string

--- a/cmd/ltx/encode_db_test.go
+++ b/cmd/ltx/encode_db_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/superfly/ltx"
+)
+
+func TestEncodeDBCommand(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db")
+		writeSQLiteDatabase(t, dbPath)
+
+		outPath := filepath.Join(dir, "ltx")
+		oldData := bytes.Repeat([]byte("x"), 1<<20)
+		if err := os.WriteFile(outPath, oldData, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := NewEncodeDBCommand().Run(context.Background(), []string{"-o", outPath, dbPath}); err != nil {
+			t.Fatal(err)
+		}
+
+		f, err := os.Open(outPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = f.Close() })
+
+		dec := ltx.NewDecoder(f)
+		if err := dec.Verify(); err != nil {
+			t.Fatal(err)
+		} else if got, want := dec.Header().Version, ltx.Version; got != want {
+			t.Fatalf("version=%d, want %d", got, want)
+		}
+
+		if info, err := f.Stat(); err != nil {
+			t.Fatal(err)
+		} else if got, wantMax := info.Size(), int64(len(oldData)-1); got > wantMax {
+			t.Fatalf("size=%d, want <= %d", got, wantMax)
+		}
+	})
+
+	t.Run("ErrSameFile", func(t *testing.T) {
+		for _, tt := range []struct {
+			name  string
+			alias func(*testing.T, string) string
+		}{
+			{
+				name: "SamePath",
+				alias: func(t *testing.T, dbPath string) string {
+					return dbPath
+				},
+			},
+			{
+				name: "HardLink",
+				alias: func(t *testing.T, dbPath string) string {
+					t.Helper()
+					outPath := filepath.Join(filepath.Dir(dbPath), "ltx")
+					if err := os.Link(dbPath, outPath); err != nil {
+						t.Fatal(err)
+					}
+					return outPath
+				},
+			},
+			{
+				name: "SymbolicLink",
+				alias: func(t *testing.T, dbPath string) string {
+					t.Helper()
+					outPath := filepath.Join(filepath.Dir(dbPath), "ltx")
+					if err := os.Symlink(dbPath, outPath); err != nil {
+						t.Fatal(err)
+					}
+					return outPath
+				},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				dbPath := filepath.Join(t.TempDir(), "db")
+				want := writeSQLiteDatabase(t, dbPath)
+				outPath := tt.alias(t, dbPath)
+
+				if err := NewEncodeDBCommand().Run(context.Background(), []string{"-o", outPath, dbPath}); err == nil || err.Error() != "input and output files are the same" {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if got, err := os.ReadFile(dbPath); err != nil {
+					t.Fatal(err)
+				} else if !bytes.Equal(got, want) {
+					t.Fatal("database changed")
+				}
+			})
+		}
+	})
+
+	t.Run("ErrPreservesOutput", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db")
+		db := writeSQLiteDatabase(t, dbPath)
+		if err := os.WriteFile(dbPath, db[:len(db)/2], 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		outPath := filepath.Join(dir, "ltx")
+		want := []byte("existing output")
+		if err := os.WriteFile(outPath, want, 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := NewEncodeDBCommand().Run(context.Background(), []string{"-o", outPath, dbPath}); err == nil || err.Error() != "read page 2: EOF" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got, err := os.ReadFile(outPath); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(got, want) {
+			t.Fatalf("output=%q, want %q", got, want)
+		}
+
+		if entries, err := os.ReadDir(dir); err != nil {
+			t.Fatal(err)
+		} else if got, want := len(entries), 2; got != want {
+			t.Fatalf("entry count=%d, want %d", got, want)
+		}
+	})
+}
+
+func writeSQLiteDatabase(t *testing.T, path string) []byte {
+	t.Helper()
+
+	const (
+		pageSize = 512
+		pageN    = 2
+	)
+
+	b := make([]byte, pageSize*pageN)
+	copy(b, SQLITE_DATABASE_HEADER_STRING)
+	binary.BigEndian.PutUint16(b[16:], pageSize)
+	binary.BigEndian.PutUint32(b[28:], pageN)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return b
+}


### PR DESCRIPTION
## Summary
- encode database snapshots with the current LTX version
- atomically replace destination files while rejecting input/output aliases and preserving existing output on failure
- add command-level round-trip and file-safety regression coverage

## Test Plan
- go test ./... -count=1
- go vet ./...
- go build ./cmd/ltx
- encode a real SQLite database and verify the generated snapshot with the CLI

Fixes #81
Fixes #87