### PR TITLE
fix(apply): honor checksum-free files

### DIFF
--- a/cmd/ltx/apply.go
+++ b/cmd/ltx/apply.go
@@ -78,20 +78,23 @@ func (c *ApplyCommand) applyLTXFile(_ context.Context, dbFile *os.File, filename
 	if err := dec.DecodeHeader(); err != nil {
 		return fmt.Errorf("decode ltx header: %w", err)
 	}
+	hdr := dec.Header()
 
 	// Read checksum before applying.
-	if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-	preApplyChecksum, err := ltx.ChecksumReader(dbFile, int(dec.Header().PageSize))
-	if err != nil {
-		return fmt.Errorf("compute pre-apply checksum: %w", err)
-	} else if preApplyChecksum != dec.Header().PreApplyChecksum {
-		return fmt.Errorf("pre-apply checksum mismatch: %s <> %s", preApplyChecksum, dec.Header().PreApplyChecksum)
+	if !hdr.IsSnapshot() && !hdr.NoChecksum() {
+		if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		preApplyChecksum, err := ltx.ChecksumReader(dbFile, int(hdr.PageSize))
+		if err != nil {
+			return fmt.Errorf("compute pre-apply checksum: %w", err)
+		} else if preApplyChecksum != hdr.PreApplyChecksum {
+			return fmt.Errorf("pre-apply checksum mismatch: %s <> %s", preApplyChecksum, hdr.PreApplyChecksum)
+		}
 	}
 
 	// Apply each page to the database.
-	data := make([]byte, dec.Header().PageSize)
+	data := make([]byte, hdr.PageSize)
 	for {
 		var pageHeader ltx.PageHeader
 		if err := dec.DecodePage(&pageHeader, data); err == io.EOF {
@@ -100,7 +103,7 @@ func (c *ApplyCommand) applyLTXFile(_ context.Context, dbFile *os.File, filename
 			return fmt.Errorf("decode ltx page: %w", err)
 		}
 
-		offset := int64(pageHeader.Pgno-1) * int64(dec.Header().PageSize)
+		offset := int64(pageHeader.Pgno-1) * int64(hdr.PageSize)
 		if _, err := dbFile.WriteAt(data, offset); err != nil {
 			return fmt.Errorf("write database page: %w", err)
 		}
@@ -110,16 +113,21 @@ func (c *ApplyCommand) applyLTXFile(_ context.Context, dbFile *os.File, filename
 	if err := dec.Close(); err != nil {
 		return fmt.Errorf("close ltx file: %w", err)
 	}
+	if err := dbFile.Truncate(int64(hdr.Commit) * int64(hdr.PageSize)); err != nil {
+		return fmt.Errorf("truncate database: %w", err)
+	}
 
 	// Recalculate database checksum and ensure it matches the LTX checksum.
-	if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-	postApplyChecksum, err := ltx.ChecksumReader(dbFile, int(dec.Header().PageSize))
-	if err != nil {
-		return fmt.Errorf("compute post-apply checksum: %w", err)
-	} else if postApplyChecksum != dec.Trailer().PostApplyChecksum {
-		return fmt.Errorf("post-apply checksum mismatch: %s <> %s", postApplyChecksum, dec.Trailer().PostApplyChecksum)
+	if !hdr.NoChecksum() {
+		if _, err := dbFile.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		postApplyChecksum, err := ltx.ChecksumReader(dbFile, int(hdr.PageSize))
+		if err != nil {
+			return fmt.Errorf("compute post-apply checksum: %w", err)
+		} else if postApplyChecksum != dec.Trailer().PostApplyChecksum {
+			return fmt.Errorf("post-apply checksum mismatch: %s <> %s", postApplyChecksum, dec.Trailer().PostApplyChecksum)
+		}
 	}
 
 	return nil

--- a/cmd/ltx/apply_test.go
+++ b/cmd/ltx/apply_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/superfly/ltx"
+)
+
+func TestApplyCommand_NoChecksumSnapshot(t *testing.T) {
+	const pageSize = 512
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	ltxPath := filepath.Join(dir, "snapshot.ltx")
+	want := bytes.Repeat([]byte{0x12}, pageSize)
+	writeApplyTestLTX(t, ltxPath, &ltx.FileSpec{
+		Header: ltx.Header{
+			Version:  ltx.Version,
+			Flags:    ltx.HeaderFlagNoChecksum,
+			PageSize: pageSize,
+			Commit:   1,
+			MinTXID:  1,
+			MaxTXID:  1,
+		},
+		Pages: []ltx.PageSpec{
+			{Header: ltx.PageHeader{Pgno: 1}, Data: want},
+		},
+	})
+
+	if err := NewApplyCommand().Run(context.Background(), []string{"-db", dbPath, ltxPath}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(dbPath); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, want) {
+		t.Fatalf("database mismatch:\ngot=%x\nwant=%x", got, want)
+	}
+}
+
+func TestApplyCommand_NoChecksumIncremental(t *testing.T) {
+	const pageSize = 512
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	ltxPath := filepath.Join(dir, "incremental.ltx")
+	initial := bytes.Repeat([]byte{0x34}, 2*pageSize)
+	want := bytes.Repeat([]byte{0x56}, pageSize)
+	if err := os.WriteFile(dbPath, initial, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	writeApplyTestLTX(t, ltxPath, &ltx.FileSpec{
+		Header: ltx.Header{
+			Version:  ltx.Version,
+			Flags:    ltx.HeaderFlagNoChecksum,
+			PageSize: pageSize,
+			Commit:   1,
+			MinTXID:  2,
+			MaxTXID:  2,
+		},
+		Pages: []ltx.PageSpec{
+			{Header: ltx.PageHeader{Pgno: 1}, Data: want},
+		},
+	})
+
+	if err := NewApplyCommand().Run(context.Background(), []string{"-db", dbPath, ltxPath}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(dbPath); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, want) {
+		t.Fatalf("database mismatch:\ngot=%x\nwant=%x", got, want)
+	}
+}
+
+func TestApplyCommand_SnapshotOverExistingDatabase(t *testing.T) {
+	const pageSize = 512
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "db")
+	ltxPath := filepath.Join(dir, "snapshot.ltx")
+	initial := bytes.Repeat([]byte{0x78}, 2*pageSize)
+	want := bytes.Repeat([]byte{0x9a}, pageSize)
+	if err := os.WriteFile(dbPath, initial, 0o666); err != nil {
+		t.Fatal(err)
+	}
+	writeApplyTestLTX(t, ltxPath, &ltx.FileSpec{
+		Header: ltx.Header{
+			Version:  ltx.Version,
+			PageSize: pageSize,
+			Commit:   1,
+			MinTXID:  1,
+			MaxTXID:  1,
+		},
+		Pages: []ltx.PageSpec{
+			{Header: ltx.PageHeader{Pgno: 1}, Data: want},
+		},
+		Trailer: ltx.Trailer{PostApplyChecksum: ltx.ChecksumPage(1, want)},
+	})
+
+	if err := NewApplyCommand().Run(context.Background(), []string{"-db", dbPath, ltxPath}); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(dbPath); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(got, want) {
+		t.Fatalf("database mismatch:\ngot=%x\nwant=%x", got, want)
+	}
+}
+
+func writeApplyTestLTX(t *testing.T, path string, spec *ltx.FileSpec) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := spec.WriteTo(f); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Honor HeaderFlagNoChecksum by skipping both database checksum comparisons while continuing to verify LTX file integrity.
- Skip pre-apply database checksum validation for snapshots because their zero checksum means there is no predecessor, allowing snapshots to replace existing destinations.
- Truncate the destination to Header.Commit * Header.PageSize after integrity verification. The #86 fix is deliberately bundled with #82 because shipping the NoChecksum guard alone would turn shrinking transactions from a loud checksum failure into silent corruption by leaving stale pages.

## Test Plan
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `go build ./cmd/ltx`

Fixes #82
Fixes #86