### PR TITLE
perf(encoder): store page index in chunked slices, not a map

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -6,7 +6,6 @@ import (
 	"hash"
 	"hash/crc64"
 	"io"
-	"slices"
 
 	"github.com/pierrec/lz4/v4"
 )
@@ -19,8 +18,8 @@ type Encoder struct {
 	header  Header
 	trailer Trailer
 	hash    hash.Hash64
-	index   map[uint32]PageIndexElem // page number to offset
-	n       int64                    // bytes written
+	index   pageIndex // pages in write order (ascending pgno)
+	n       int64     // bytes written
 
 	// LZ4 block compression
 	compressor  lz4.Compressor
@@ -36,7 +35,6 @@ func NewEncoder(w io.Writer) (*Encoder, error) {
 	return &Encoder{
 		w:     w,
 		state: stateHeader,
-		index: make(map[uint32]PageIndexElem),
 	}, nil
 }
 
@@ -120,24 +118,20 @@ func (enc *Encoder) Close() error {
 func (enc *Encoder) encodePageIndex() error {
 	offset := enc.n
 
-	// Write elements in sorted page number order.
-	pgnos := make([]uint32, 0, len(enc.index))
-	for pgno := range enc.index {
-		pgnos = append(pgnos, pgno)
-	}
-	slices.Sort(pgnos)
-
+	// EncodePage enforces strictly ascending page numbers, so the index is
+	// already in sorted order.
+	//
 	// Write each element as a varint-encoded tuple.
 	buf := make([]byte, 0, 3*binary.MaxVarintLen64)
-	for _, pgno := range pgnos {
-		elem := enc.index[pgno]
+	for _, chunk := range enc.index.chunks {
+		for _, elem := range chunk {
+			buf = binary.AppendUvarint(buf[:0], uint64(elem.pgno))
+			buf = binary.AppendUvarint(buf, uint64(elem.offset))
+			buf = binary.AppendUvarint(buf, uint64(elem.size))
 
-		buf = binary.AppendUvarint(buf[:0], uint64(pgno))
-		buf = binary.AppendUvarint(buf, uint64(elem.Offset))
-		buf = binary.AppendUvarint(buf, uint64(elem.Size))
-
-		if _, err := enc.write(buf); err != nil {
-			return fmt.Errorf("write page index element: %w", err)
+			if _, err := enc.write(buf); err != nil {
+				return fmt.Errorf("write page index element: %w", err)
+			}
 		}
 	}
 
@@ -269,10 +263,11 @@ func (enc *Encoder) EncodePage(hdr PageHeader, data []byte) (err error) {
 
 	enc.pagesWritten++
 	enc.prevPgno = hdr.Pgno
-	enc.index[hdr.Pgno] = PageIndexElem{
-		Offset: offset,
-		Size:   enc.n - offset,
-	}
+	enc.index.append(pageIndexEntry{
+		pgno:   hdr.Pgno,
+		offset: offset,
+		size:   enc.n - offset,
+	})
 
 	return nil
 }
@@ -287,6 +282,46 @@ func (enc *Encoder) write(b []byte) (n int, err error) {
 func (enc *Encoder) writeToHash(b []byte) {
 	_, _ = enc.hash.Write(b)
 	enc.n += int64(len(b))
+}
+
+// pageIndexEntry is the encoder's in-memory page index element: a compact
+// 24-byte struct rather than a map entry. Large snapshots retain one element
+// per page, and the map representation cost roughly 4x as much memory per
+// page plus rehash spikes while growing (litestream issue #1477).
+type pageIndexEntry struct {
+	pgno   uint32
+	offset int64
+	size   int64
+}
+
+const (
+	// pageIndexMinChunk is the capacity of the first index chunk (6 KiB), so
+	// the many small LTX files written on every sync stay cheap.
+	pageIndexMinChunk = 1 << 8
+	// pageIndexMaxChunk caps chunk capacity (1.5 MiB per chunk).
+	pageIndexMaxChunk = 1 << 16
+)
+
+// pageIndex is an append-only sequence of pageIndexEntry stored in chunks
+// whose capacity doubles from pageIndexMinChunk up to pageIndexMaxChunk.
+// Chunking keeps memory proportional to the pages actually encoded: there is
+// no upfront allocation sized from the (caller-supplied) header commit count
+// and no copy of the whole index when it grows.
+type pageIndex struct {
+	chunks [][]pageIndexEntry
+}
+
+func (idx *pageIndex) append(e pageIndexEntry) {
+	n := len(idx.chunks)
+	if n == 0 || len(idx.chunks[n-1]) == cap(idx.chunks[n-1]) {
+		size := pageIndexMinChunk
+		if n > 0 {
+			size = min(2*cap(idx.chunks[n-1]), pageIndexMaxChunk)
+		}
+		idx.chunks = append(idx.chunks, make([]pageIndexEntry, 0, size))
+	}
+	last := &idx.chunks[len(idx.chunks)-1]
+	*last = append(*last, e)
 }
 
 type PageIndexElem struct {

--- a/encoder_golden_test.go
+++ b/encoder_golden_test.go
@@ -1,0 +1,137 @@
+package ltx_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/superfly/ltx"
+)
+
+// TestEncoder_PageIndexGolden pins the file checksum of deterministic files
+// captured from the map-based encoder, so the append-only page index stays
+// byte-for-byte compatible on the wire (the checksum covers the page index
+// tuples in order, so any reordering or size drift changes it).
+func TestEncoder_PageIndexGolden(t *testing.T) {
+	page := func(seed byte) []byte {
+		b := make([]byte, 512)
+		for i := range b {
+			b[i] = seed + byte(i%7)
+		}
+		return b
+	}
+
+	t.Run("SparseNonSnapshot", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc, err := ltx.NewEncoder(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{
+			Version:          ltx.Version,
+			PageSize:         512,
+			Commit:           16,
+			MinTXID:          2,
+			MaxTXID:          3,
+			Timestamp:        1000,
+			PreApplyChecksum: ltx.ChecksumFlag | 1,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		for _, pgno := range []uint32{2, 5, 9, 16} {
+			if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, page(byte(pgno))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		enc.SetPostApplyChecksum(ltx.ChecksumFlag | 2)
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := enc.Trailer().FileChecksum, ltx.Checksum(0xe27f4c18f0da2c10); got != want {
+			t.Fatalf("FileChecksum=%#x, want %#x", uint64(got), uint64(want))
+		}
+	})
+
+	t.Run("Snapshot", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc, err := ltx.NewEncoder(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.EncodeHeader(ltx.Header{
+			Version:   ltx.Version,
+			PageSize:  512,
+			Commit:    6,
+			MinTXID:   1,
+			MaxTXID:   4,
+			Timestamp: 1000,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		for pgno := uint32(1); pgno <= 6; pgno++ {
+			if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, page(byte(pgno))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		enc.SetPostApplyChecksum(ltx.ChecksumFlag | 3)
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if got, want := enc.Trailer().FileChecksum, ltx.Checksum(0xd926967672f7ca53); got != want {
+			t.Fatalf("FileChecksum=%#x, want %#x", uint64(got), uint64(want))
+		}
+	})
+}
+
+// TestEncoder_PageIndexChunkBoundaries encodes enough pages to span several
+// index chunks (including the maximum chunk size) and verifies the decoded
+// index has every page in ascending order with contiguous offsets.
+func TestEncoder_PageIndexChunkBoundaries(t *testing.T) {
+	const pageSize, n = 512, 2*65536 + 259
+
+	page := make([]byte, pageSize)
+	var buf bytes.Buffer
+	enc, err := ltx.NewEncoder(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.EncodeHeader(ltx.Header{
+		Version:          ltx.Version,
+		PageSize:         pageSize,
+		Commit:           n + 1,
+		MinTXID:          2,
+		MaxTXID:          2,
+		Timestamp:        1000,
+		PreApplyChecksum: ltx.ChecksumFlag | 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for pgno := uint32(2); pgno <= n+1; pgno++ {
+		if err := enc.EncodePage(ltx.PageHeader{Pgno: pgno}, page); err != nil {
+			t.Fatalf("pgno %d: %v", pgno, err)
+		}
+	}
+	enc.SetPostApplyChecksum(ltx.ChecksumFlag | 2)
+	if err := enc.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	dec := ltx.NewDecoder(bytes.NewReader(buf.Bytes()))
+	if err := dec.Verify(); err != nil {
+		t.Fatal(err)
+	}
+	index := dec.PageIndex()
+	if got, want := len(index), n; got != want {
+		t.Fatalf("index size=%d, want %d", got, want)
+	}
+	var prev ltx.PageIndexElem
+	for pgno := uint32(2); pgno <= n+1; pgno++ {
+		elem, ok := index[pgno]
+		if !ok {
+			t.Fatalf("pgno %d missing from index", pgno)
+		}
+		if pgno > 2 && elem.Offset != prev.Offset+prev.Size {
+			t.Fatalf("pgno %d offset=%d, want contiguous after %d+%d", pgno, elem.Offset, prev.Offset, prev.Size)
+		}
+		prev = elem
+	}
+}


### PR DESCRIPTION
## Summary

`Encoder` kept its page index in a `map[uint32]PageIndexElem` and sorted the keys on `Close`. `EncodePage` already rejects any page number that is not strictly greater than the previous one, so the map never provided anything a slice does not: entries can be appended in write order and streamed out directly.

The map is the dominant memory cost of encoding a large file. One entry per page at roughly 90 B live (plus rehash spikes while the map grows) is ~2.9 GiB for a 34M-page snapshot — the main linear term in https://github.com/benbjohnson/litestream/issues/1477, where a 130 GiB database was OOM-killed in a 12 GiB container. A packed 24-byte entry is ~0.8 GiB for the same file.

- Entries live in chunks whose capacity doubles from 256 entries up to 64K (1.5 MiB). Memory stays proportional to the pages actually encoded: the small files written on every sync cost a few KiB, nothing is preallocated from the caller-supplied `Header.Commit` (which `Compactor` copies from unverified input), and growth never copies the whole index.
- `encodePageIndex` drops the collect-and-sort pass.
- Wire format is unchanged. `TestEncoder_PageIndexGolden` pins the `FileChecksum` of a sparse non-snapshot file and a contiguous snapshot, captured from the map-based encoder on `main` (the checksum covers the index tuples in order, so any reordering or offset drift fails it). `TestEncoder_PageIndexChunkBoundaries` decodes an index spanning several chunks.
- `PageIndexElem` and the decoder API are untouched.

## Evidence

Measured with the litestream-soak `snapshot-compaction-overlap` rig (https://github.com/corylanou/litestream-soak/pull/196): Litestream `main` (3b468c9) built against ltx `v0.5.2` versus this branch, same fixture, `runtime.MemStats` sampled at 100 ms with GOGC=25, heap profile written at each phase's peak. Heap growth is peak `HeapInuse` minus the phase's post-GC baseline.

| ltx | DB | initial L0 sync | snapshot | L1 compaction |
|---|---|---|---|---|
| v0.5.2 | 1 GiB / 262,803 pages | 35.3 MB (134 B/pg) | 69.0 MB (263 B/pg) | 101.3 MB (386 B/pg) |
| this PR | 1 GiB / 262,803 pages | 9.1 MB (35 B/pg) | 48.0 MB (183 B/pg) | 77.0 MB (293 B/pg) |
| v0.5.2 | 4 GiB / 1,051,216 pages | 137.4 MB (131 B/pg) | 168.6 MB (160 B/pg) | 306.3 MB (291 B/pg) |
| this PR | 4 GiB / 1,051,216 pages | 31.4 MB (30 B/pg) | 70.3 MB (67 B/pg) | 204.3 MB (194 B/pg) |

Each phase includes a fixed 32 MB of S3 multipart buffers (part size × concurrency+1), so the per-page deltas are larger than the totals suggest: the encoder index goes from ~95 B/page to ~25 B/page. Peak heap profiles (`inuse_space`, 4 GiB snapshot phase):

```
v0.5.2:   99.23MB ltx.(*Encoder).EncodePage
           32.00MB s3/manager.(*maxSlicePool).newSlice
this PR:  19.04MB ltx.(*pageIndex).append
           32.00MB s3/manager.(*maxSlicePool).newSlice
```

Combined with the per-database maintenance serialization in the companion Litestream PR (linked in a comment below), the #1477 overlap drops from ~450 B/page on today's code to ~195 B/page (4 GiB fixture: 470.6 MB → 205.6 MB), i.e. ≈15 GB → ≈6.7 GB at the reporter's 34.2M pages. With that change alone the biggest remaining per-page cost is the decoder-side map noted below (`DecodePageIndex`, 81 MB in the 4 GiB compaction profile).

## Follow-up (not in this PR)

The decoder side (`DecodePageIndex` / `Decoder.PageIndex`) still returns a `map[uint32]PageIndexElem`, which is now the largest remaining per-page term during compaction (~70 B/page). Changing that is a public API change and belongs in its own PR.

## Test plan

- [x] `go test ./...`, `go vet ./...`, gofmt
- [x] Golden checksums captured from `main` (8cb8f8e) before the change and asserted after
- [x] Chunk-boundary round trip (2×65,536 + 259 pages)
- [x] Rig A/B above at 1 GiB and 4 GiB
- [x] Two adversarial Codex review passes; the preallocation-from-header finding from the first pass drove the chunked design
