### PR TITLE
fix(tests): resolve lint warnings

### DIFF
--- a/checksum_test.go
+++ b/checksum_test.go
@@ -80,7 +80,11 @@ func testChecksumPages(t *testing.T, fileSize, nPages, pageSize, nWorkers uint32
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer f.Close()
+		t.Cleanup(func() {
+			if err := f.Close(); err != nil {
+				t.Error(err)
+			}
+		})
 		if _, err := io.CopyN(f, rand.Reader, int64(fileSize)); err != nil {
 			t.Fatal(err)
 		}
@@ -108,12 +112,16 @@ func testChecksumPages(t *testing.T, fileSize, nPages, pageSize, nWorkers uint32
 }
 
 // logic copied from litefs repo
-func legacyChecksumPages(dbPath string, pageSize, nPages uint32, checksums []Checksum) (uint32, error) {
+func legacyChecksumPages(dbPath string, pageSize, nPages uint32, checksums []Checksum) (lastPage uint32, err error) {
 	f, err := os.Open(dbPath)
 	if err != nil {
 		return 0, err
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+	}()
 
 	buf := make([]byte, pageSize)
 

--- a/ltx_test.go
+++ b/ltx_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"reflect"
 	"testing"
@@ -695,7 +695,7 @@ func BenchmarkChecksumPage(b *testing.B) {
 
 func benchmarkChecksumPage(b *testing.B, pageSize int) {
 	data := make([]byte, pageSize)
-	_, _ = rand.Read(data)
+	_, _ = rand.NewChaCha8([32]byte{}).Read(data)
 	b.ReportAllocs()
 	b.SetBytes(int64(pageSize))
 	b.ResetTimer()
@@ -715,7 +715,7 @@ func BenchmarkChecksumPageWithHasher(b *testing.B) {
 
 func benchmarkChecksumPageWithHasher(b *testing.B, pageSize int) {
 	data := make([]byte, pageSize)
-	_, _ = rand.Read(data)
+	_, _ = rand.NewChaCha8([32]byte{}).Read(data)
 	b.ReportAllocs()
 	b.SetBytes(int64(pageSize))
 	b.ResetTimer()
@@ -733,8 +733,9 @@ func BenchmarkXOR(b *testing.B) {
 
 	m := make(map[uint32]ltx.Checksum)
 	page := make([]byte, pageSize)
+	rnd := rand.NewChaCha8([32]byte{})
 	for pgno := uint32(1); pgno <= pageN; pgno++ {
-		_, _ = rand.Read(page)
+		_, _ = rnd.Read(page)
 		m[pgno] = ltx.ChecksumPage(pgno, page)
 	}
 	b.SetBytes(int64(pageN * pageSize))


### PR DESCRIPTION
## Summary

- report checksum test-helper close failures without replacing earlier operation errors
- generate deterministic benchmark fixture data outside timed sections

Fixes #99

## Test Plan

- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint run`
- run the affected checksum and XOR benchmarks with one iteration